### PR TITLE
fix: Fixes link options having no effect

### DIFF
--- a/src/utils/markdown/index.js
+++ b/src/utils/markdown/index.js
@@ -6,7 +6,11 @@ import { usertag, usertagHtml } from './usertag'
 const addLinkOptions = (html, { linkOptions }) => {
 	return html.replaceAll('href', (match) => {
 		return `target=${linkOptions.target} rel=${linkOptions.rel} ${match}`
-	});
+	})
+};
+
+const removeLinks = (html) => {
+	return html.replaceAll(/<a.*?>(.*?)<\/a>/g, '$1');
 };
 
 export default (text, { textFormatting }) => {
@@ -45,6 +49,15 @@ export default (text, { textFormatting }) => {
 				{
 					types: [],
 					value: element.innerText
+				}
+			]
+		}
+
+		if (textFormatting.linkOptions.disabled) {
+			return [
+				{
+					types: ['markdown'],
+					value: removeLinks(markdown)
 				}
 			]
 		}

--- a/src/utils/markdown/index.js
+++ b/src/utils/markdown/index.js
@@ -3,6 +3,12 @@ import { gfm, gfmHtml } from 'micromark-extension-gfm'
 import { underline, underlineHtml } from './underline'
 import { usertag, usertagHtml } from './usertag'
 
+const addLinkOptions = (html, { linkOptions }) => {
+	return html.replaceAll('href', (match) => {
+		return `target=${linkOptions.target} rel=${linkOptions.rel} ${match}`
+	});
+};
+
 export default (text, { textFormatting }) => {
 	if (textFormatting) {
 		let gfmDisabled = []
@@ -46,7 +52,7 @@ export default (text, { textFormatting }) => {
 		return [
 			{
 				types: ['markdown'],
-				value: markdown
+				value: addLinkOptions(markdown, textFormatting)
 			}
 		]
 	}


### PR DESCRIPTION
### Descrição 📝 
* Ajusta para que os links enviados no Chat sejam `target=_blank`;
* Fixes #3 

### Como testar 🐛 
* Enviar um link no Chat;
* Clicar nele;
* Verificar se ele será aberto em uma nova guia;