### PR TITLE
fix: New message undoing chats filtering (issue #26)

### DIFF
--- a/demo/src/ChatContainer.vue
+++ b/demo/src/ChatContainer.vue
@@ -46,7 +46,7 @@
 			:menu-actions="JSON.stringify(menuActions)"
 			:message-selection-actions="JSON.stringify(messageSelectionActions)"
 			:templates-text="JSON.stringify(templatesText)"
-			:no-rooms-found-message="'No conversation found'"
+			:rooms-not-found-message="'Nenhum conversa encontrada...'"
 			@fetch-more-rooms="fetchMoreRooms"
 			@fetch-messages="fetchMessages($event.detail[0])"
 			@send-message="sendMessage($event.detail[0])"
@@ -82,8 +82,7 @@ import * as storageService from '@/database/storage'
 import { parseTimestamp, formatTimestamp } from '@/utils/dates'
 import logoAvatar from '@/assets/logo.png'
 
-import { register } from 'vue-advanced-chat'
-// import { register } from './../../dist/vue-advanced-chat.es.js'
+import { register } from './../../dist/vue-advanced-chat.es.js'
 // import { register } from './../../src/lib/index.js'
 register()
 

--- a/demo/src/ChatContainer.vue
+++ b/demo/src/ChatContainer.vue
@@ -82,8 +82,8 @@ import * as storageService from '@/database/storage'
 import { parseTimestamp, formatTimestamp } from '@/utils/dates'
 import logoAvatar from '@/assets/logo.png'
 
-// import { register } from 'vue-advanced-chat'
-import { register } from './../../dist/vue-advanced-chat.es.js'
+import { register } from 'vue-advanced-chat'
+// import { register } from './../../dist/vue-advanced-chat.es.js'
 // import { register } from './../../src/lib/index.js'
 register()
 

--- a/demo/src/ChatContainer.vue
+++ b/demo/src/ChatContainer.vue
@@ -46,6 +46,7 @@
 			:menu-actions="JSON.stringify(menuActions)"
 			:message-selection-actions="JSON.stringify(messageSelectionActions)"
 			:templates-text="JSON.stringify(templatesText)"
+			:no-rooms-found-message="'No conversation found'"
 			@fetch-more-rooms="fetchMoreRooms"
 			@fetch-messages="fetchMessages($event.detail[0])"
 			@send-message="sendMessage($event.detail[0])"
@@ -81,8 +82,8 @@ import * as storageService from '@/database/storage'
 import { parseTimestamp, formatTimestamp } from '@/utils/dates'
 import logoAvatar from '@/assets/logo.png'
 
-import { register } from 'vue-advanced-chat'
-// import { register } from './../../dist/vue-advanced-chat.es.js'
+// import { register } from 'vue-advanced-chat'
+import { register } from './../../dist/vue-advanced-chat.es.js'
 // import { register } from './../../src/lib/index.js'
 register()
 

--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -18,7 +18,7 @@
 				:link-options="linkOptionsCasted"
 				:is-mobile="isMobile"
 				:scroll-distance="scrollDistance"
-				:no-rooms-found-message="noRoomsFoundMessage"
+				:rooms-not-found-message="roomsNotFoundMessage"
 				@fetch-room="fetchRoom"
 				@fetch-more-rooms="fetchMoreRooms"
 				@loading-more-rooms="loadingMoreRooms = $event"
@@ -208,7 +208,7 @@ export default {
 			default: () => ({ minUsers: 3, currentUser: false })
 		},
 		emojiDataSource: { type: String, default: undefined },
-		noRoomsFoundMessage: { type: String, default: '' }
+		roomsNotFoundMessage: { type: String, default: '' }
 	},
 
 	emits: [

--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -18,6 +18,7 @@
 				:link-options="linkOptionsCasted"
 				:is-mobile="isMobile"
 				:scroll-distance="scrollDistance"
+				:no-rooms-found-message="noRoomsFoundMessage"
 				@fetch-room="fetchRoom"
 				@fetch-more-rooms="fetchMoreRooms"
 				@loading-more-rooms="loadingMoreRooms = $event"
@@ -206,7 +207,8 @@ export default {
 			type: [Object, String],
 			default: () => ({ minUsers: 3, currentUser: false })
 		},
-		emojiDataSource: { type: String, default: undefined }
+		emojiDataSource: { type: String, default: undefined },
+		noRoomsFoundMessage: { type: String, default: '' }
 	},
 
 	emits: [
@@ -229,7 +231,7 @@ export default {
 		'search-room',
 		'room-action-handler',
 		'message-selection-action-handler',
-    'message-reaction-click'
+		'message-reaction-click',
 	],
 
 	data() {

--- a/src/lib/RoomsList/RoomsList.scss
+++ b/src/lib/RoomsList/RoomsList.scss
@@ -88,4 +88,9 @@
 	.rooms-leave-active {
 		position: absolute;
 	}
+
+	.no-rooms-found-message {
+		padding: 2rem;
+		text-align: center;
+	}
 }

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -78,7 +78,7 @@
 				empty query AND when it matches no room.
 			-->
 			<div class="no-rooms-found-message" v-if="roomsQuery.length && !filteredRooms.length">
-				{{ noRoomsFoundMessage }}
+				{{ roomsNotFoundMessage }}
 			</div>
 		</transition>
 	</div>
@@ -116,7 +116,7 @@ export default {
 		customSearchRoomEnabled: { type: [Boolean, String], default: false },
 		roomActions: { type: Array, required: true },
 		scrollDistance: { type: Number, required: true },
-		noRoomsFoundMessage: { type: String, required: true }
+		roomsNotFoundMessage: { type: String, required: true }
 	},
 
 	emits: [

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -37,10 +37,10 @@
 			</slot>
 		</div>
 
-		<div v-if="!loadingRooms" id="rooms-list" class="vac-room-list">
+		<div v-if="!loadingRooms && roomsToDisplay.length" id="rooms-list" class="vac-room-list">
 			<transition-group name="rooms">
 				<div
-					v-for="fRoom in filteredRooms"
+					v-for="fRoom in roomsToDisplay"
 					:id="fRoom.roomId"
 					:key="fRoom.roomId"
 					class="vac-room-item"
@@ -72,6 +72,15 @@
 				</div>
 			</transition>
 		</div>
+		<transition name="vac-fade-message">
+			<!--
+				I only want to show this label when there is a non
+				empty query AND when it matches no room.
+			-->
+			<div class="no-rooms-found-message" v-if="roomsQuery.length && !filteredRooms.length">
+				{{ noRoomsFoundMessage }}
+			</div>
+		</transition>
 	</div>
 </template>
 
@@ -106,7 +115,8 @@ export default {
 		room: { type: Object, required: true },
 		customSearchRoomEnabled: { type: [Boolean, String], default: false },
 		roomActions: { type: Array, required: true },
-		scrollDistance: { type: Number, required: true }
+		scrollDistance: { type: Number, required: true },
+		noRoomsFoundMessage: { type: String, required: true }
 	},
 
 	emits: [
@@ -120,11 +130,22 @@ export default {
 
 	data() {
 		return {
-			filteredRooms: this.rooms || [],
+			filteredRooms: [],
 			observer: null,
 			showLoader: true,
 			loadingMoreRooms: false,
-			selectedRoomId: ''
+			selectedRoomId: '',
+			roomsQuery: '',
+		}
+	},
+
+	computed: {
+		roomsToDisplay: function() {
+			if (this.roomsQuery.length) {
+				return this.filteredRooms;
+			}
+
+			return this.rooms;
 		}
 	},
 
@@ -132,7 +153,6 @@ export default {
 		rooms: {
 			deep: true,
 			handler(newVal, oldVal) {
-				this.filteredRooms = newVal
 				if (newVal.length !== oldVal.length || this.roomsLoaded) {
 					this.loadingMoreRooms = false
 				}
@@ -194,6 +214,7 @@ export default {
 			if (this.customSearchRoomEnabled) {
 				this.$emit('search-room', ev.target.value)
 			} else {
+				this.roomsQuery = ev.target.value;
 				this.filteredRooms = filteredItems(
 					this.rooms,
 					'roomName',

--- a/src/utils/filter-items.js
+++ b/src/utils/filter-items.js
@@ -12,4 +12,5 @@ function formatString(string) {
 		.toLowerCase()
 		.normalize('NFD')
 		.replace(/[\u0300-\u036f]/g, '')
+		.trim()
 }


### PR DESCRIPTION
### Descrição 📝 
* Ajusta para que uma nova mensagem não desfaça o filtro de chats;
* Fixes #26 

### Prévia 👀 
![image](https://github.com/optidatacloud/vue-advanced-chat/assets/19571204/dc6499ef-c0dc-457c-84d8-4e5ba4e83c21)


### Como testar 🐛 
#### Caso 1
* Acessar o Chat com dois usuários;
* Filtrar chats em um deles;
* Mandar uma mensagem com o outro usuário;
* Verificar que o filtro de chats não será desfeito;
#### Caso 2
* Filtrar nenhuma conversa;
* Ver que será mostrado o texto: "Nenhum conversa encontrada" (ver imagem acima);
