### PR TITLE
feat: filter out users that leave room from tagging selection list (issue #53)

### DIFF
--- a/src/lib/Room/RoomFooter/RoomFooter.vue
+++ b/src/lib/Room/RoomFooter/RoomFooter.vue
@@ -867,7 +867,7 @@ export default {
 				'username',
 				query,
 				true
-			).filter(user => user._id !== this.currentUserId)
+			).filter(user => user._id !== this.currentUserId && user.isInRoom)
 		},
 		selectUserTag(user, editMode = false) {
 			this.selectUsersTagItem = false

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,6 +14,7 @@ export interface RoomUser {
 	username: string
 	avatar: string
 	status: UserStatus
+	isInRoom?: boolean
 }
 
 export interface MessageFile {


### PR DESCRIPTION
### Descrição 📝 
* Ajusta para não exibir usuários que sairam do Chat na `tagging selection list`;
* O que acontecia antes é que tu ainda podia marcar alguém que tinha saido do Chat;
* resolves #53 

### Como testar 🐛 
* Testar na issue do Chat;