### PR TITLE
feat: show search input when loading rooms

### DIFF
--- a/demo/src/ChatContainer.vue
+++ b/demo/src/ChatContainer.vue
@@ -46,7 +46,6 @@
 			:menu-actions="JSON.stringify(menuActions)"
 			:message-selection-actions="JSON.stringify(messageSelectionActions)"
 			:templates-text="JSON.stringify(templatesText)"
-			:rooms-not-found-message="'Nenhum conversa encontrada...'"
 			@fetch-more-rooms="fetchMoreRooms"
 			@fetch-messages="fetchMessages($event.detail[0])"
 			@send-message="sendMessage($event.detail[0])"

--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -5,6 +5,7 @@
         v-if="!singleRoomCasted"
         :current-user-id="currentUserId"
         :rooms="orderedRooms"
+        :custom-search-rooms="customSearchRoomsCasted"
         :loading-rooms="loadingRoomsCasted"
         :rooms-loaded="roomsLoadedCasted"
         :room="room"
@@ -39,6 +40,7 @@
       <room
         :current-user-id="currentUserId"
         :rooms="roomsCasted"
+        :custom-search-rooms="customSearchRoomsCasted"
         :room-id="room.roomId || ''"
         :load-first-room="loadFirstRoomCasted"
         :messages="messagesCasted"
@@ -158,6 +160,7 @@ export default {
     textMessages: { type: [Object, String], default: () => ({}) },
     currentUserId: { type: String, default: '' },
     rooms: { type: [Array, String], default: () => [] },
+    customSearchRooms: { type: [Array, String], default: () => [] },
     roomsOrder: { type: String, default: 'desc' },
     loadingRooms: { type: [Boolean, String], default: false },
     roomsLoaded: { type: [Boolean, String], default: false },
@@ -391,6 +394,9 @@ export default {
     },
     roomsCasted() {
       return this.castArray(this.rooms)
+    },
+    customSearchRoomsCasted() {
+      return this.castArray(this.customSearchRooms)
     },
     messagesCasted() {
       return this.castArray(this.messages)

--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -19,7 +19,6 @@
         :link-options="linkOptionsCasted"
         :is-mobile="isMobile"
         :scroll-distance="scrollDistance"
-        :rooms-not-found-message="roomsNotFoundMessage"
         :show-archived-rooms="showArchivedRoomsCasted"
         @fetch-room="fetchRoom"
         @fetch-more-rooms="fetchMoreRooms"
@@ -233,7 +232,6 @@ export default {
       default: () => ({ minUsers: 3, currentUser: false })
     },
     emojiDataSource: { type: String, default: undefined },
-    roomsNotFoundMessage: { type: String, default: '' },
     attachmentOptions: { type: Array, default: () => [] },
     call: { type: [Object, String], default: () => ({}) },
     textareaHighlight: { type: Boolean, default: false },

--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -481,10 +481,6 @@ export default {
       }
     },
 
-    loadingRoomsCasted(val) {
-      if (val) this.room = {}
-    },
-
     roomId: {
       immediate: true,
       handler(newVal, oldVal) {

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -211,7 +211,9 @@ export default {
           if (!this.loadingRooms) {
             this.showLoader = false
           }
+          return
         }
+        this.showLoader = true
       }
     },
     room: {

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -164,13 +164,15 @@ export default {
 
   computed: {
     roomsToDisplay: function() {
-      let roomsToReturn = this.roomsQuery.length ? this.filteredRooms : this.rooms
-
-      if (this.showArchivedRooms) {
-        return roomsToReturn.filter(room => room.isArchived)
+      if (!this.roomsQuery.length) {
+        return this.rooms
       }
 
-      return roomsToReturn.filter(room => !room.isArchived)
+      if (this.customSearchRoomEnabled) {
+        return this.customSearchRooms
+      }
+
+      return this.filteredRooms
     },
     hasArchivedRooms: function() {
       return this.rooms.some(room => room.isArchived)

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -31,7 +31,8 @@
       </template>
     </loader>
 
-    <div v-if="!loadingRooms && !rooms.length" class="vac-rooms-empty">
+    <!-- If any of filtered array has no length then show: "no results found" -->
+    <div v-if="!loadingRooms && roomsQuery.length && !this.customSearchRooms.length && !this.filteredRooms.length" class="vac-rooms-empty">
       <slot name="rooms-empty">
         {{ textMessages.ROOMS_EMPTY }}
       </slot>
@@ -204,9 +205,9 @@ export default {
           if (!this.loadingRooms) {
             this.showLoader = false
           }
-          return
+        } else {
+          this.showLoader = true
         }
-        this.showLoader = true
       }
     },
     room: {

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -243,10 +243,10 @@ export default {
       }
     },
     searchRoom(ev) {
+      this.roomsQuery = ev.target.value
       if (this.customSearchRoomEnabled) {
         this.$emit('search-room', ev.target.value)
       } else {
-        this.roomsQuery = ev.target.value
         this.filteredRooms = filteredItems(
           this.rooms,
           ['roomName', 'email'],
@@ -255,6 +255,7 @@ export default {
       }
     },
     openRoom(room) {
+      this.roomsQuery = ''
       if (room.roomId === this.room.roomId && !this.isMobile) return
       if (!this.isMobile) this.selectedRoomId = room.roomId
       this.$emit('fetch-room', { room })

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -94,15 +94,6 @@
         </div>
       </transition>
     </div>
-    <transition name="vac-fade-message">
-      <!--
-        I only want to show this label when there is a non
-        empty query AND when it matches no room.
-      -->
-      <div v-if="roomsQuery.length && !filteredRooms.length" class="no-rooms-found-message">
-        {{ roomsNotFoundMessage }}
-      </div>
-    </transition>
   </div>
 </template>
 
@@ -142,7 +133,6 @@ export default {
     customSearchRoomEnabled: { type: [Boolean, String], default: false },
     roomActions: { type: Array, required: true },
     scrollDistance: { type: Number, required: true },
-    roomsNotFoundMessage: { type: String, required: true },
     call: { type: Object, required: true },
     showArchivedRooms: { type: Boolean, required: true }
   },

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -127,6 +127,7 @@ export default {
     linkOptions: { type: Object, required: true },
     isMobile: { type: Boolean, required: true },
     rooms: { type: Array, required: true },
+    customSearchRooms: { type: Array, required: false, default: () => []},
     loadingRooms: { type: Boolean, required: true },
     roomsLoaded: { type: Boolean, required: true },
     room: { type: Object, required: true },

--- a/src/lib/RoomsList/RoomsSearch/RoomsSearch.vue
+++ b/src/lib/RoomsList/RoomsSearch/RoomsSearch.vue
@@ -6,13 +6,12 @@
     }"
   >
     <template v-if="showSearch">
-      <div v-if="!loadingRooms && rooms.length" class="vac-icon-search">
+      <div class="vac-icon-search">
         <slot name="search-icon">
           <svg-icon name="search" />
         </slot>
       </div>
       <input
-        v-if="!loadingRooms && rooms.length"
         type="search"
         :placeholder="textMessages.SEARCH"
         autocomplete="off"


### PR DESCRIPTION
### Descrição 📝 
* Ajustei para que o campo de busca apareça ao mesmo tempo com o loader (antes se o loader estava na tela o input de busca não aparecia);
* Adicionei o propriedade `customSearchRooms` que usei pra armazenar o resultado da pesquisa
  * Preferi separar `rooms` de `customSearchRooms` por que facilitou a implementação no Chat;
* Removi a `roomsNotFoundMessage` (que adicionei a um tempo atrás) pq o VAC já tinha uma prop pra isso;
* Corrige um detalhe que fazia o evento `load-more-rooms` não ser disparado;
* fix #72;

### Como testar 🐛 
* Testar aqui: https://github.com/optidatacloud/optiwork-chat/pull/752