### PR TITLE
redo: fixes call buttons (issues #70, pr #75)

### DIFF
--- a/src/lib/Room/RoomMessage/RoomMessage.vue
+++ b/src/lib/Room/RoomMessage/RoomMessage.vue
@@ -555,7 +555,7 @@ export default {
     },
 
     truncateMessageIfNeeded() {
-      const isFileMessage = this.isAudio || this.message.files.length > 1
+      const isFileMessage = this.isAudio || this.message.files?.length > 1
       const shouldTruncate = this.maxMessageRows > 0 && !this.message.replyMessage && this.$refs.messageBox && !isFileMessage && this.message.distributed
       if (!shouldTruncate) {
         this.hasTruncatedContent = false

--- a/src/lib/RoomsList/RoomCallContent/RoomCallContent.scss
+++ b/src/lib/RoomsList/RoomCallContent/RoomCallContent.scss
@@ -5,6 +5,7 @@
   width: 100%;
 
   .vac-room-info-container {
+    min-width: 260px;
     flex: 1;
     display: flex;
   }
@@ -46,7 +47,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  padding: 1rem 0;  
+  padding: 1rem 0;
 
   a.btn {
     text-decoration: none;

--- a/src/lib/RoomsList/RoomCallContent/RoomCallContent.scss
+++ b/src/lib/RoomsList/RoomCallContent/RoomCallContent.scss
@@ -5,7 +5,7 @@
   width: 100%;
 
   .vac-room-info-container {
-    min-width: 1;
+    min-width: 1px;
     flex: 1;
     display: flex;
   }

--- a/src/lib/RoomsList/RoomCallContent/RoomCallContent.scss
+++ b/src/lib/RoomsList/RoomCallContent/RoomCallContent.scss
@@ -5,7 +5,7 @@
   width: 100%;
 
   .vac-room-info-container {
-    min-width: 260px;
+    min-width: 1;
     flex: 1;
     display: flex;
   }

--- a/src/lib/RoomsList/RoomsList.scss
+++ b/src/lib/RoomsList/RoomsList.scss
@@ -117,3 +117,9 @@
     }
   }
 }
+
+@media only screen and (max-width: 1200px) {
+  .vac-rooms-container {
+    flex: 0 0 35%;
+  }
+}


### PR DESCRIPTION
- Fixes #70

### :memo: Descrição

Este PR corrige um problema encontrado nos testes da chamada do chat. Em telas pequenas, os botões de chamada acabavam ficando ocultos.

### :test_tube: Como testar

Não requer testes (testar na chamada do chat).