### PR TITLE
chore: Adjusts archived to handle pagination (issue #74)

### DIFF
--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -5,6 +5,7 @@
         v-if="!singleRoomCasted"
         :current-user-id="currentUserId"
         :rooms="orderedRooms"
+        :archived-rooms="archivedRoomsCasted"
         :custom-search-rooms="customSearchRoomsCasted"
         :loading-rooms="loadingRoomsCasted"
         :rooms-loaded="roomsLoadedCasted"
@@ -40,6 +41,8 @@
       <room
         :current-user-id="currentUserId"
         :rooms="roomsCasted"
+        :archived-rooms="archivedRoomsCasted"
+        :show-archived-rooms="showArchivedRoomsCasted"
         :custom-search-rooms="customSearchRoomsCasted"
         :room-id="room.roomId || ''"
         :load-first-room="loadFirstRoomCasted"
@@ -161,6 +164,7 @@ export default {
     currentUserId: { type: String, default: '' },
     rooms: { type: [Array, String], default: () => [] },
     customSearchRooms: { type: [Array, String], default: () => [] },
+    archivedRooms: { type: Array, default: () => []},
     roomsOrder: { type: String, default: 'desc' },
     loadingRooms: { type: [Boolean, String], default: false },
     roomsLoaded: { type: [Boolean, String], default: false },
@@ -322,6 +326,9 @@ export default {
 
         return aVal > bVal ? -1 : bVal > aVal ? 1 : 0
       })
+    },
+    archivedRoomsCasted() {
+      return this.castArray(this.archivedRooms)
     },
     singleRoomCasted() {
       return this.castBoolean(this.singleRoom)
@@ -485,7 +492,7 @@ export default {
       immediate: true,
       handler(newVal, oldVal) {
         if (newVal && !this.loadingRoomsCasted && this.roomsCasted.length) {
-          const room = this.roomsCasted.find(r => r.roomId === newVal)
+          const room = this.showArchivedRoomsCasted ? this.archivedRoomsCasted.find(r => r.roomId === newVal) : this.roomsCasted.find(r => r.roomId === newVal)
           this.fetchRoom({ room })
         } else if (oldVal && !newVal) {
           this.room = {}
@@ -617,8 +624,8 @@ export default {
     hangUpCallHandler(call) {
       this.$emit('hang-up-call', call)
     },
-    clickArchivedRoomsHandler() {
-      this.$emit('click-archived-rooms')
+    clickArchivedRoomsHandler(event) {
+      this.$emit('click-archived-rooms', event)
     },
     messageActionHandler(ev) {
       this.$emit('message-action-handler', {

--- a/src/lib/Room/Room.vue
+++ b/src/lib/Room/Room.vue
@@ -306,10 +306,7 @@ export default {
 
   computed: {
     room() {
-      if (this.showArchivedRooms) {
-        return this.archivedRooms.find(room => room.roomId === this.roomId) || {}
-      }
-      return this.rooms.find(room => room.roomId === this.roomId) || {}
+      return this.rooms.find(room => room.roomId === this.roomId) || this.archivedRooms.find(room => room.roomId === this.roomId) || {}
     },
     showNoMessages() {
       return (

--- a/src/lib/Room/Room.vue
+++ b/src/lib/Room/Room.vue
@@ -318,7 +318,7 @@ export default {
     },
     showNoRoom() {
       const noRoomSelected =
-        (!this.rooms.length && !this.loadingRooms) ||
+        (!this.rooms.length && !this.archivedRooms.length && !this.loadingRooms) ||
         (!this.roomId && !this.loadFirstRoom)
 
       if (noRoomSelected) {

--- a/src/lib/Room/Room.vue
+++ b/src/lib/Room/Room.vue
@@ -218,6 +218,8 @@ export default {
     showRoomsList: { type: Boolean, required: true },
     isMobile: { type: Boolean, required: true },
     rooms: { type: Array, required: true },
+    archivedRooms: { type: Array, required: true },
+    showArchivedRooms: { type: Boolean, required: true },
     roomId: { type: [String, Number], required: true },
     loadFirstRoom: { type: Boolean, required: true },
     messages: { type: Array, required: true },
@@ -304,6 +306,9 @@ export default {
 
   computed: {
     room() {
+      if (this.showArchivedRooms) {
+        return this.archivedRooms.find(room => room.roomId === this.roomId) || {}
+      }
       return this.rooms.find(room => room.roomId === this.roomId) || {}
     },
     showNoMessages() {

--- a/src/lib/RoomsList/RoomsList.scss
+++ b/src/lib/RoomsList/RoomsList.scss
@@ -20,7 +20,7 @@
     color: #9ca6af;
     font-style: italic;
     text-align: center;
-    margin: 40px 0;
+    margin: 30px 15px;
     line-height: 20px;
     white-space: pre-line;
   }
@@ -73,22 +73,29 @@
     }
   }
 
-  .rooms-move,
+  .rooms-move, /* apply transition to moving elements */
   .rooms-enter-active,
-  .rooms-leave-active {
-    transition: all 1s cubic-bezier(0.075, 0.82, 0.165, 1);
+  .rooms-leave-active,
+  .rooms-archived-move,
+  .rooms-archived-enter-active,
+  .rooms-archived-leave-active {
+    transition: all 0.5s ease;
   }
 
-  .rooms-enter-from {
-    opacity: 0;
-    transform: translateY(2rem);
-  }
-
+  .rooms-enter-from,
   .rooms-leave-to {
     opacity: 0;
+    transform: translateX(-30px);
   }
 
-  .rooms-leave-active {
+  .rooms-archived-enter-from,
+  .rooms-archived-leave-to {
+    opacity: 0;
+    transform: translateX(60px);
+  }
+
+  .rooms-leave-active,
+  .rooms-archived-leave-active {
     position: absolute;
   }
 

--- a/src/lib/RoomsList/RoomsList.scss
+++ b/src/lib/RoomsList/RoomsList.scss
@@ -102,19 +102,21 @@
   }
 
   .vac-rooms-archived {
-    border-radius: 8px;
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
     align-items: center;
     display: flex;
-    flex: 1 1 100%;
-    margin-bottom: 5px;
-    padding: 0 14px;
-    position: relative;
-    min-height: 71px;
-    transition: background-color 0.3s cubic-bezier(0.25, 0.8, 0.5, 1);
+    padding: 7px 30px;
+    min-height: 35px;
+    font-weight: 500;
+    cursor: pointer;
+    user-select: none;
+  }
 
-    &:hover {
-      background: var(--chat-sidemenu-bg-color-hover);
-    }
+  .rooms-archived-icon {
+    font-size: 1.4rem;
+    margin-right: 1rem;
+    color: var(--chat-bg-color-button);
   }
 }
 

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -24,7 +24,7 @@
         </template>
       </rooms-search>
 
-      <div class="vac-rooms-archived" @click="clickArchivedRooms">
+      <div class="vac-rooms-archived" @click="clickArchivedRooms" v-if="showSearch">
         <div class="rooms-archived-icon">
           <i v-if="showArchivedRooms" class="bi bi-arrow-left"></i>
           <i v-else class="bi bi-archive-fill"></i>

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -288,6 +288,9 @@ export default {
       const canAcceptCall = room.call && !room.call.attendance.statusCallEnded && !room.call.attendance.statusDeclined
 
       return !hasCallEnded && canAcceptCall
+    },
+    clickArchivedRooms() {
+      this.$emit('click-archived-rooms', !this.showArchivedRooms )
     }
   }
 }

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -23,6 +23,16 @@
           <slot :name="name" v-bind="data" />
         </template>
       </rooms-search>
+
+      <div class="vac-rooms-archived" @click="clickArchivedRooms">
+        <div class="rooms-archived-icon">
+          <i v-if="showArchivedRooms" class="bi bi-arrow-left"></i>
+          <i v-else class="bi bi-archive-fill"></i>
+        </div>
+        <div>
+          {{ textMessages.ARCHIVED_ROOMS }}
+        </div>
+      </div>
     </slot>
 
     <loader :show="loadingRooms" type="rooms">

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -41,14 +41,15 @@
       </template>
     </loader>
 
-    <!-- If any of filtered array has no length then show: "no results found" -->
-    <div v-if="!loadingRooms && roomsQuery.length && !customSearchRooms.length && !filteredRooms.length" class="vac-rooms-empty">
+    <!-- Displayed when user searches for something and result it's empty -->
+    <div v-if="!loadingRooms && roomsQuery.length && !customSearchRooms.length && !roomsToDisplay.length" class="vac-rooms-empty xesquedele pinto">
       <slot name="rooms-empty">
         {{ textMessages.ROOMS_EMPTY }}
       </slot>
     </div>
 
-    <div v-if="!loadingRooms && showArchivedRooms && !archivedRooms.length" class="vac-rooms-empty">
+    <!-- Displayed when user has no archived rooms -->
+    <div v-if="!loadingRooms && !roomsQuery.length && showArchivedRooms && !archivedRooms.length" class="vac-rooms-empty">
       <slot name="rooms-empty">
         {{ textMessages.ARCHIVED_ROOMS_EMPTY }}
       </slot>

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -96,7 +96,7 @@
         </div>
       </transition-group>
       <transition name="vac-fade-message">
-        <div v-if="rooms.length && !loadingRooms" id="infinite-loader-rooms">
+        <div v-if="(rooms.length || archivedRooms.length || customSearchRooms.length) && !loadingRooms" id="infinite-loader-rooms">
           <loader :show="showLoader" :infinite="true" type="infinite-rooms">
             <template v-for="(idx, name) in $slots" #[name]="data">
               <slot :name="name" v-bind="data" />
@@ -232,6 +232,7 @@ export default {
     showArchivedRooms: {
       handler() {
         this.roomsQuery = ''
+        setTimeout(() => this.initIntersectionObserver())
       }
     }
   },


### PR DESCRIPTION
### Descrição 📝 
* Ajustei para que os chats arquivados sejam passados em um array específico (isso deixou o tratamento mais simples);
* O fluxo dos arquivados envolve 1 evento e 2 propriedades:
  * `show-archived-rooms`: usado para alternar entre as rooms "normais" e arquivadas;
  * `archived-rooms`: array usado para armazenar as rooms arquivadas (preferi separar em outro array pq deixou as coisas simples);
  * `click-archived-rooms`: evento que escuto quando a opção é clicada;
* resolves #74;

### Como testar 🐛
* Testar no pull request do Chat:
* https://github.com/optidatacloud/optiwork-chat/pull/764;