### PR TITLE
feat: preview pdf files (issue #839 pr #80)

### DIFF
--- a/src/lib/MediaPreview/MediaPreview.scss
+++ b/src/lib/MediaPreview/MediaPreview.scss
@@ -19,6 +19,18 @@ $media-preview-width-sm: 20px;
     width: calc(100% - #{$media-preview-width-lg * 2});
     padding: $media-preview-height $media-preview-width-lg;
     margin: 0 auto;
+    
+    .vac-iframe-preview-container {
+      width: 100%;
+      height: 100%;
+      z-index: 999;
+
+      .vac-iframe-preview-pdf {
+        width: 100%;
+        height: 100%;
+        border: none;
+      }
+    }
   }
 
   .vac-image-preview {

--- a/src/lib/MediaPreview/MediaPreview.vue
+++ b/src/lib/MediaPreview/MediaPreview.vue
@@ -21,6 +21,18 @@
           <source :src="file.url" />
         </video>
       </div>
+
+      <div v-else-if="isPdf" class="vac-media-preview-container">
+				<div class="vac-iframe-preview-container">
+          <iframe
+            :src="file.url"
+            title="PDF Viewer"
+            class="vac-iframe-preview-pdf"
+            @load="onIframeFinishedLoading"
+          />
+					<loader :show="isLoadingIframe" type="messages" />
+				</div>
+			</div>
     </transition>
 
     <div class="vac-svg-button">
@@ -31,13 +43,16 @@
   </div>
 </template>
 <script>
+
+import Loader from '../../components/Loader/Loader'
 import SvgIcon from '../../components/SvgIcon/SvgIcon'
 
-import { isImageFile, isVideoFile } from '../../utils/media-file'
+import { isImageFile, isVideoFile, isPdfFile } from '../../utils/media-file'
 
 export default {
   name: 'MediaPreview',
   components: {
+    Loader,
     SvgIcon
   },
 
@@ -47,12 +62,21 @@ export default {
 
   emits: ['close-media-preview'],
 
+  data() {
+    return {
+      isLoadingIframe: true
+    }
+  },
+
   computed: {
     isImage() {
       return isImageFile(this.file)
     },
     isVideo() {
       return isVideoFile(this.file)
+    },
+    isPdf() {
+      return isPdfFile(this.file)
     }
   },
 
@@ -63,6 +87,9 @@ export default {
   methods: {
     closeModal() {
       this.$emit('close-media-preview')
+    },
+    onIframeFinishedLoading() {
+      this.isLoadingIframe = false
     }
   }
 }

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFiles.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFiles.vue
@@ -28,7 +28,7 @@
       <div
         class="vac-file-container"
         :class="{ 'vac-file-container-progress': file.progress >= 0 }"
-        @click="openFile($event, file, 'download')"
+        @click="openFile($event, file)"
       >
         <div class="vac-svg-button">
           <slot name="document-icon">
@@ -89,10 +89,21 @@ export default {
   },
 
   methods: {
-    openFile(event, file, action) {
-      if (!this.messageSelectionEnabled) {
-        event.stopPropagation()
-        this.$emit('open-file', { file, action })
+    openFile(event, file) {
+      if (this.messageSelectionEnabled) {
+        return
+      }
+      event.stopPropagation()
+
+      // determine action based on file type
+      switch (file.type) {
+      case 'application/pdf':
+        this.$emit('open-file', { file, action: 'preview' })
+        break
+
+      default:
+        this.$emit('open-file', { file, action: 'download' })
+        break
       }
     }
   }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,4 @@
 export const IMAGE_TYPES = ['png', 'jpg', 'jpeg', 'webp', 'svg', 'gif']
 export const VIDEO_TYPES = ['mp4', 'video/ogg', 'webm', 'quicktime']
 export const AUDIO_TYPES = ['mp3', 'audio/ogg', 'wav', 'mpeg']
+export const PDF_TYPES = ['pdf', 'application/pdf']

--- a/src/utils/media-file.js
+++ b/src/utils/media-file.js
@@ -1,4 +1,4 @@
-import { IMAGE_TYPES, VIDEO_TYPES, AUDIO_TYPES } from './constants'
+import { IMAGE_TYPES, VIDEO_TYPES, AUDIO_TYPES, PDF_TYPES } from './constants'
 
 function checkMediaType(types, file) {
   if (!file || !file.type) return
@@ -19,4 +19,8 @@ export function isImageVideoFile(file) {
 
 export function isAudioFile(file) {
   return checkMediaType(AUDIO_TYPES, file)
+}
+
+export function isPdfFile(file) {
+  return checkMediaType(PDF_TYPES, file)
 }


### PR DESCRIPTION
> Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/839

### Descrição
- Esse PR tem como objetivo exibir um modal para pré-visualizar arquivos do tipo PDF, removendo a necessidade do usuário de fazer o download do arquivo toda vez, similar ao preview já existente no drive.

### Prévia
- Captura de tela mostrando o preview do PDF:
![image](https://github.com/user-attachments/assets/b8014cc7-4648-4e86-9234-13034a530f66)

### Como testar:
- Faça o envio de qualquer arquivo do tipo PDF em uma conversa e clique sobre ele para visualizar.

Fix: #839 