### PR TITLE
feat: click on message avatar to open side menu (issue #860 pr #81)

### DIFF
--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -88,6 +88,7 @@
         :external-files="externalFilesCasted"
         :allow-sending-external-files="allowSendingExternalFiles"
         :max-message-rows="maxMessageRows"
+        @avatar-click="onAvatarClick"
         @toggle-rooms-list="toggleRoomsList"
         @room-info="roomInfo"
         @fetch-messages="fetchMessages"
@@ -561,6 +562,13 @@ export default {
     },
     roomInfo() {
       this.$emit('room-info', this.room)
+    },
+    onAvatarClick(id) {
+      if (this.room?.isIndividual) {
+        this.roomInfo()
+      } else {
+        this.$emit('room-info', { senderId: id })
+      }
     },
     addRoom() {
       this.$emit('add-room')

--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -566,9 +566,9 @@ export default {
     onAvatarClick(id) {
       if (this.room?.isIndividual) {
         this.roomInfo()
-      } else {
-        this.$emit('room-info', { senderId: id })
+        return
       }
+      this.$emit('room-info', { senderId: id })
     },
     addRoom() {
       this.$emit('add-room')

--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -568,7 +568,7 @@ export default {
         this.roomInfo()
         return
       }
-      this.$emit('room-info', { senderId: id })
+      this.$emit('room-info', { userId: id })
     },
     addRoom() {
       this.$emit('add-room')

--- a/src/lib/Room/Room.vue
+++ b/src/lib/Room/Room.vue
@@ -101,6 +101,7 @@
                 @message-action-handler="messageActionHandler"
                 @open-file="openFile"
                 @open-user-tag="openUserTag"
+                @avatar-click="$emit('avatar-click', $event)"
                 @open-failed-message="$emit('open-failed-message', $event)"
                 @send-message-reaction="sendMessageReaction"
                 @select-message="selectMessage"
@@ -287,7 +288,8 @@ export default {
     'external-files-removed',
     'new-draft-message',
     'message-reply-click',
-    'click-message-username'
+    'click-message-username',
+    'avatar-click'
   ],
 
   data() {

--- a/src/lib/Room/RoomMessage/RoomMessage.vue
+++ b/src/lib/Room/RoomMessage/RoomMessage.vue
@@ -109,7 +109,9 @@
             <div
               v-if="message.avatar && !messageSelectionEnabled"
               class="vac-avatar"
+              style="cursor: pointer"
               :style="{ 'background-image': `url('${message.avatar}')` }"
+              @click="onMessageAvatarClicked(message)"
             />
           </slot>
           <div
@@ -364,7 +366,8 @@ export default {
     'unselect-message',
     'message-reaction-click',
     'message-reply-click',
-    'click-message-username'
+    'click-message-username',
+    'avatar-click'
   ],
 
   data() {
@@ -473,6 +476,11 @@ export default {
   },
 
   methods: {
+    onMessageAvatarClicked(msg) {
+      const id = msg?.senderId
+      if (!id) return
+      this.$emit('avatar-click', id)
+    },
     onHoverMessage() {
       if (!this.messageSelectionEnabled) {
         this.messageHover = !this.isSelectingContent && true

--- a/src/lib/Room/RoomMessage/RoomMessage.vue
+++ b/src/lib/Room/RoomMessage/RoomMessage.vue
@@ -478,7 +478,9 @@ export default {
   methods: {
     onMessageAvatarClicked(msg) {
       const id = msg?.senderId
-      if (!id) return
+      if (!id) {
+        return
+      }
       this.$emit('avatar-click', id)
     },
     onHoverMessage() {


### PR DESCRIPTION
> Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/860#issue-2406184469

### Descrição
- Esse PR adiciona a funcionalidade de clicar sobre o avatar de quem fez o envio da mensagem e mostrar as informações desse contato no menu lateral

### Prévia
- Captura de tela mostrando o painel lateral:
![image](https://github.com/user-attachments/assets/e9168fcb-fa07-45cd-b5b8-dacb06cb2c96)

### Como testar:
- Abra uma conversa com outra pessoa (individual ou em grupo) e clique sobre a foto/nome dela no topo da conversa, um menu lateral deve aparecer exibindo as informações desse contato.

Fix: https://github.com/optidatacloud/optiwork-chat/issues/860#issue-2406184469 