### PR TITLE
 feat: copy message text (issue #863 pr #82)

### DIFF
--- a/src/lib/Room/Room.vue
+++ b/src/lib/Room/Room.vue
@@ -583,7 +583,7 @@ export default {
         500
       )
     },
-    messageActionHandler({ action, message }) {
+    async messageActionHandler({ action, message }) {
       switch (action.name) {
       case 'replyMessage':
         this.initReplyMessage = message
@@ -602,6 +602,13 @@ export default {
       case 'selectMessages':
         this.selectedMessages = [message]
         this.messageSelectionEnabled = true
+        return
+      case 'copyMessage':
+        if (!message?.content) {
+          return
+        }
+
+        await navigator.clipboard.writeText(message?.content)
         return
       default:
         return this.$emit('message-action-handler', { action, message })

--- a/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
+++ b/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
@@ -76,7 +76,7 @@
       >
         <div class="vac-menu-list">
           <div v-for="action in filteredMessageActions" :key="action.name">
-            <div class="vac-menu-item" :class="{ 'vac-action-disabled': action.name === 'copyMessage' && message.content === '' }" @click="messageActionHandler(action)">
+            <div class="vac-menu-item" :class="{ 'vac-action-disabled': action?.disableIfContentIsNull && message.content === '' }" @click="messageActionHandler(action)">
               {{ action.title }}
             </div>
           </div>

--- a/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
+++ b/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
@@ -76,7 +76,7 @@
       >
         <div class="vac-menu-list">
           <div v-for="action in filteredMessageActions" :key="action.name">
-            <div class="vac-menu-item" @click="messageActionHandler(action)">
+            <div class="vac-menu-item" :class="{ 'vac-action-disabled': action.name === 'copyMessage' && message.content === '' }" @click="messageActionHandler(action)">
               {{ action.title }}
             </div>
           </div>

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -5,6 +5,10 @@
   background: var(--chat-dropdown-bg-color);
   padding: 6px 0;
 
+  .vac-action-disabled {
+    pointer-events: none;
+  }
+
   :hover {
     background: var(--chat-dropdown-bg-color-hover);
     transition: background-color 0.3s cubic-bezier(0.25, 0.8, 0.5, 1);


### PR DESCRIPTION
> Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/863

### Descrição
- Esse PR adiciona a funcionalidade de copiar o conteúdo de uma mensagem através do menu de ações.

### Prévia
- Captura de tela mostrando a ação de copiar:
![image](https://github.com/user-attachments/assets/d63b45a1-b0a4-4ea0-ae7f-167f74b17540)

### Como testar:
- Abra uma conversa com outra pessoa (individual ou em grupo) e clique nas opções da mensagem, se a imagem contiver um conteúdo texto a botão estará disponível e ao clicar o conteúdo deve ser copiado para a área de transferência.

Fix: https://github.com/optidatacloud/optiwork-chat/issues/863