### PR TITLE
 fix: message reaction icon position (issue #870 pr #83)

### DIFF
--- a/src/lib/Room/Room.vue
+++ b/src/lib/Room/Room.vue
@@ -583,7 +583,7 @@ export default {
         500
       )
     },
-    messageActionHandler({ action, message }) {
+    async messageActionHandler({ action, message }) {
       switch (action.name) {
       case 'replyMessage':
         this.initReplyMessage = message
@@ -602,6 +602,13 @@ export default {
       case 'selectMessages':
         this.selectedMessages = [message]
         this.messageSelectionEnabled = true
+        return
+      case 'copyMessage':
+        if (!message?.content) {
+          return
+        }
+
+        await navigator.clipboard.writeText(message?.content)
         return
       default:
         return this.$emit('message-action-handler', { action, message })

--- a/src/lib/Room/RoomMessage/MessageActions/MessageActions.scss
+++ b/src/lib/Room/RoomMessage/MessageActions/MessageActions.scss
@@ -1,35 +1,28 @@
 .vac-message-actions-wrapper {
   .vac-options-container {
     position: absolute;
-    top: 2px;
-    right: 10px;
+    top: 4px;
+    right: -40px;
     height: 40px;
-    width: 70px;
-    overflow: hidden;
-    border-top-right-radius: 8px;
+    width: 50px;
   }
 
   .vac-blur-container {
     position: absolute;
     height: 100%;
     width: 100%;
-    left: 8px;
-    bottom: 10px;
+    right: 0;
+    top: 0;
     background: var(--chat-message-bg-color);
-    filter: blur(3px);
-    border-bottom-left-radius: 8px;
-  }
-
-  .vac-options-me {
-    background: var(--chat-message-bg-color-me);
+    filter: blur(8px);
   }
 
   .vac-message-options {
     background: var(--chat-icon-bg-dropdown-message);
     border-radius: 50%;
     position: absolute;
-    top: 7px;
-    right: 7px;
+    top: 25%;
+    left: 5px;
 
     svg {
       height: 17px;
@@ -41,8 +34,8 @@
 
   .vac-message-emojis {
     position: absolute;
-    top: 6px;
-    right: 30px;
+    top: 8px;
+    left: 25px;
   }
 
   .vac-menu-options {
@@ -50,16 +43,37 @@
   }
 
   .vac-menu-left {
-    right: -118px;
+    right: -150px;
+    top: 35px;
+  }
+}
+
+.vac-message-me {
+  position: absolute;
+  top: 0;
+  left: -50px;
+
+  .vac-options-container {
+    right: -60px;
   }
 
-  @media only screen and (max-width: 768px) {
-    .vac-options-container {
-      right: 3px;
-    }
+  .vac-blur-container {
+    height: 100%;
+    width: 100%;
+    right: 0;
+    top: 0;
+  }
 
-    .vac-menu-left {
-      right: -50px;
-    }
+  .vac-message-options {
+    left: 25px;
+  }
+
+  .vac-message-emojis {
+    left: 5px;
+  }
+
+  .vac-menu-options {
+    right: -50px;
+    top: 35px;
   }
 }

--- a/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
+++ b/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
@@ -1,21 +1,19 @@
 <template>
-  <div class="vac-message-actions-wrapper" :style="{ display: message.deleted ? 'none' : '' }">
+  <div
+    class="vac-message-actions-wrapper"
+    :style="{ display: message.deleted ? 'none' : '' }"
+    :class="{
+      'vac-message-me': message.senderId === currentUserId
+    }"
+  >
     <div
       class="vac-options-container"
-      :style="{
-        display: hoverAudioProgress || !messageHover ? 'none' : 'initial',
-        width:
-          filteredMessageActions.length && showReactionEmojis ? '70px' : '45px'
-      }"
     >
-      <transition-group name="vac-slide-left" tag="span">
+      <transition-group :name="message.senderId === currentUserId ? 'vac-slide-left' : 'vac-slide-right'" tag="span">
         <div
           v-if="isMessageActions || isMessageReactions"
           key="1"
           class="vac-blur-container"
-          :class="{
-            'vac-options-me': message.senderId === currentUserId
-          }"
         />
 
         <div
@@ -38,7 +36,6 @@
           >
             <emoji-picker-container
               class="vac-message-emojis"
-              :style="{ right: isMessageActions ? '30px' : '5px' }"
               :emoji-opened="emojiOpened"
               :emoji-reaction="true"
               :position-right="message.senderId === currentUserId"

--- a/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
+++ b/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
@@ -76,7 +76,7 @@
       >
         <div class="vac-menu-list">
           <div v-for="action in filteredMessageActions" :key="action.name">
-            <div class="vac-menu-item" @click="messageActionHandler(action)">
+            <div class="vac-menu-item" :class="{ 'vac-action-disabled': action.name === 'copyMessage' && message.content === '' }" @click="messageActionHandler(action)">
               {{ action.title }}
             </div>
           </div>

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -5,6 +5,10 @@
   background: var(--chat-dropdown-bg-color);
   padding: 6px 0;
 
+  .vac-action-disabled {
+    pointer-events: none;
+  }
+
   :hover {
     background: var(--chat-dropdown-bg-color-hover);
     transition: background-color 0.3s cubic-bezier(0.25, 0.8, 0.5, 1);


### PR DESCRIPTION
> Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/870

### Descrição
- Esse PR ajusta o posicionamento do botão de reagir com emojis e também reposiciona o botão da lista de ações da mensagem.

### Prévia
- Captura de tela mostrando o novo posicionamento:
![image](https://github.com/user-attachments/assets/a8dfc2c9-1bec-47a4-8276-752062be1e95)

- Captura com o menu de ações expandido:
![image](https://github.com/user-attachments/assets/4f0d094e-28f2-440f-b03c-f96d9dd23093)


### Como testar:
- Abra uma conversa com outra pessoa (individual ou em grupo) e passe o mouse sobre uma mensagem enviada, os botões devem aparecer, na direita caso seja uma mensagem enviada por outra pessoa, na esquerda caso seja uma mensagem enviada por você.

Fix: https://github.com/optidatacloud/optiwork-chat/issues/870