### PR TITLE
feat: browse through medias using left and right arrows (issue #938 pr #94)

### DIFF
--- a/src/lib/MediaPreview/MediaPreview.vue
+++ b/src/lib/MediaPreview/MediaPreview.vue
@@ -165,9 +165,29 @@ export default {
     if (this.isSVG) {
       this.loadSVG(this.file)
     }
+
+    this.getModal().addEventListener('keyup', e => {
+      if (!this.showArrows) {
+        return
+      }
+
+      switch (e.key) {
+      case 'ArrowLeft':
+        this.prevMedia()
+        break
+      case 'ArrowRight':
+        this.nextMedia()
+        break
+      default:
+        break
+      }
+    })
   },
 
   methods: {
+    getModal() {
+      return this.$refs.modal
+    },
     setSVGLoading(state) {
       this.isSVGLoading = state
     },


### PR DESCRIPTION
Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/938

### Descrição:
- Adiciona um listener no modal de preview de mídias para poder navegar entre os previews utilizando as setas do teclado (`leftArrow` e `rightArrow`)

### Como testar:
- Enviar várias imagens em uma conversa, abrir o preview de uma delas e clicar com as setas do teclado para esquerda e para a direita, as midias devem ser trocadas de acordo.


Fix: [#938](https://github.com/optidatacloud/optiwork-chat/issues/938)