### PR TITLE
fix: improve emoji checking and only increase font with single emoji (issue #396 pr #97)

### DIFF
--- a/src/components/FormatMessage/FormatMessage.vue
+++ b/src/components/FormatMessage/FormatMessage.vue
@@ -7,7 +7,7 @@
       <div
         v-if="message.markdown"
         class="markdown"
-        :class="{ 'vac-emoji-message': containsOnlyEmojis(message) }"
+        :class="{ 'vac-emoji-message': containsOnlyOneEmoji(message) }"
         @click="openTag"
         v-html="message.value"
       />
@@ -70,7 +70,7 @@ import SvgIcon from '../SvgIcon/SvgIcon'
 
 import markdown from '../../utils/markdown'
 import { IMAGE_TYPES } from '../../utils/constants'
-import { containsOnlyEmojis } from '../../utils/emoji'
+import { containsOnlyEmojis, emojiCount } from '../../utils/emoji'
 
 export default {
   name: 'FormatMessage',
@@ -128,11 +128,11 @@ export default {
   },
 
   methods: {
-    containsOnlyEmojis(message) {
+    containsOnlyOneEmoji(message) {
       const div = document.createElement('div')
       div.innerHTML = message.value
       const text = div.textContent || div.innerText || ''
-      return text.length && containsOnlyEmojis(text)
+      return emojiCount(text) === 1 && containsOnlyEmojis(text)
     },
     checkType(message, type) {
       return message.types && message.types.indexOf(type) !== -1

--- a/src/utils/emoji/index.js
+++ b/src/utils/emoji/index.js
@@ -10,5 +10,9 @@ export const extractEmojis = text => {
 
 export const containsOnlyEmojis = text => {
   const emojisOnly = extractEmojis(text)
-  return emojisOnly.length === text.toString().length && hasEmoji(emojisOnly)
+  return emojiCount(text) < text.toString().length && hasEmoji(emojisOnly)
+}
+
+export const emojiCount = text => {
+  return [...new Intl.Segmenter().segment(text)].length
 }


### PR DESCRIPTION
Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/396

### Descrição:
- Adicionado um caso no código tratar emojis mais "complexos" (são formados por vários caracteres unicode).
- Aplica o aumento da fonte apenas quando a mensagem contém apenas um único emoji.

![image](https://github.com/user-attachments/assets/ea59179a-ed48-4c5a-b11f-fb5a1999a82e)

Fix: https://github.com/optidatacloud/optiwork-chat/issues/396