### PR TITLE
fix: group not loading properly (issue #967)

### DIFF
--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -413,7 +413,15 @@ export default {
       return this.castBoolean(this.mediaPreviewEnabled)
     },
     roomsCasted() {
-      return this.castArray(this.rooms)
+      const roomsToCast = [
+        this.rooms,
+        this.customSearchRooms,
+        this.archivedRooms,
+        this.groupRooms,
+        this.unreadRooms
+      ]
+
+      return roomsToCast.flatMap(this.castArray)
     },
     customSearchRoomsCasted() {
       return this.castArray(this.customSearchRooms)

--- a/src/lib/Room/Room.vue
+++ b/src/lib/Room/Room.vue
@@ -311,7 +311,7 @@ export default {
 
   computed: {
     room() {
-      return this.rooms.find(room => room.roomId === this.roomId) || this.archivedRooms.find(room => room.roomId === this.roomId) || {}
+      return this.rooms.find(room => Number(room.roomId) === Number(this.roomId)) || this.archivedRooms.find(room => Number(room.roomId) === Number(this.roomId)) || {}
     },
     showNoMessages() {
       return (

--- a/src/lib/Room/RoomFooter/RoomFooter.vue
+++ b/src/lib/Room/RoomFooter/RoomFooter.vue
@@ -362,7 +362,7 @@ export default {
   watch: {
     messages(msgs) {
       const newMessage = msgs[msgs.length - 1]
-      if (newMessage._id === newMessage.indexId) {
+      if (!newMessage || newMessage?._id === newMessage?.indexId) {
         return
       }
       this.lastMessage = newMessage

--- a/src/lib/Room/RoomMessage/RoomMessage.vue
+++ b/src/lib/Room/RoomMessage/RoomMessage.vue
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    <div v-if="newMessage._id === message._id">
+    <div v-if="newMessage?._id === message._id">
       <slot name="line-new">
         <div class="vac-line-new">
           {{ textMessages.NEW_MESSAGES }}


### PR DESCRIPTION
Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/967

### Descrição:
- O problema era que a listagem de `rooms` passado para os componentes estava incompleto.
  - Por exemplo, se vc scrollasse ou fizesse uma pesquisa no filtro de `groups` a paginação seria aplicada no filtro atual e ficaria com mais resultados do que o filtro `default`.
- Ao clicar nesse room (que estava paginado no filtro `groupRoomsCasted`, mas não em `roomCasted`) as informações desse room era buscado de `roomsCasted` o qual não continha o room recentemente carregado, fazendo com que os componentes `roomFooter` e `roomHeader` que precisavam dessa info não funcionassem corretamente (ficavam ou escondidos ou em brancos).

### Como testar
- Pesquisar por uma conversa em grupo antiga e tentar abrir ela, agora deve abrir corretamente e todas as informações e ações devem ser exibidas.





Fix: https://github.com/optidatacloud/optiwork-chat/issues/967