### PR TITLE
feat: open message actions menu with right click (issue #289)

### DIFF
--- a/src/lib/Room/Room.vue
+++ b/src/lib/Room/Room.vue
@@ -97,6 +97,8 @@
                 :selected-messages="selectedMessages"
                 :emoji-data-source="emojiDataSource"
                 :max-message-rows="maxMessageRows"
+                :message-context-menu="messageContextMenu"
+                @context-menu-opened="handleContextMenuOpened"
                 @message-added="onMessageAdded"
                 @message-action-handler="messageActionHandler"
                 @open-file="$emit('open-file', $event)"
@@ -204,6 +206,7 @@ import RoomFooter from './RoomFooter/RoomFooter'
 import RoomMessage from './RoomMessage/RoomMessage'
 
 import FileUploaderOverlay from '../../utils/uploader-overlay/'
+import { nextTick } from 'vue'
 
 export default {
   name: 'ChatRoom',
@@ -305,7 +308,8 @@ export default {
       newMessages: [],
       messageSelectionEnabled: false,
       selectedMessages: [],
-      droppedFiles: []
+      droppedFiles: [],
+      messageContextMenu: { state: 'closed', messageId: null }
     }
   },
 
@@ -654,6 +658,16 @@ export default {
       if (this.showFiles) {
         this.droppedFiles = event.dataTransfer.files
       }
+    },
+    handleContextMenuOpened(event) {
+      this.closeMessageContextMenu()
+      nextTick(async () => {
+        await new Promise(resolve => setTimeout(resolve, 100))
+        this.messageContextMenu = { state: 'opened', messageId: event.messageId }
+      })
+    },
+    closeMessageContextMenu() {
+      this.messageContextMenu = { state: 'closed', messageId: null }
     }
   }
 }

--- a/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
+++ b/src/lib/Room/RoomMessage/MessageActions/MessageActions.vue
@@ -106,7 +106,8 @@ export default {
     messageHover: { type: Boolean, required: true },
     hoverMessageId: { type: [String, Number], default: null },
     hoverAudioProgress: { type: Boolean, required: true },
-    emojiDataSource: { type: String, default: undefined }
+    emojiDataSource: { type: String, default: undefined },
+    messageContextMenu: { type: Object, default: () => ({ state: 'closed', messageId: null }) }
   },
 
   emits: [
@@ -165,6 +166,13 @@ export default {
     emojiOpened(val) {
       this.$emit('update-emoji-opened', val)
       if (val) this.optionsOpened = false
+    },
+    messageContextMenu(val) {
+      if (val.state === 'closed' || Number(val.messageId) !== Number(this.message._id)) {
+        return this.closeOptions()
+      }
+
+      this.openOptions()
     },
     optionsOpened(val) {
       this.$emit('update-options-opened', val)

--- a/src/lib/Room/RoomMessage/RoomMessage.vue
+++ b/src/lib/Room/RoomMessage/RoomMessage.vue
@@ -121,8 +121,9 @@
           <div
             class="vac-message-container"
             :class="{
-            'vac-message-container-offset': messageOffset
-          }"
+              'vac-message-container-offset': messageOffset
+            }"
+            @contextmenu="handleContextMenu"
           >
             <div
               class="vac-message-card"
@@ -253,6 +254,7 @@
                 :current-user-id="currentUserId"
                 :message="message"
                 :message-actions="messageActions"
+                :message-context-menu="messageContextMenu"
                 :show-reaction-emojis="showReactionEmojis"
                 :message-hover="messageHover"
                 :hover-message-id="hoverMessageId"
@@ -352,7 +354,8 @@ export default {
     messageSelectionEnabled: { type: Boolean, required: true },
     selectedMessages: { type: Array, default: () => [] },
     emojiDataSource: { type: String, default: undefined },
-    maxMessageRows: { type: Number, default: 0 }
+    maxMessageRows: { type: Number, default: 0 },
+    messageContextMenu: { type: Object, default: () => ({ state: 'closed', messageId: null }) }
   },
 
   emits: [
@@ -367,7 +370,8 @@ export default {
     'message-reaction-click',
     'message-reply-click',
     'click-message-username',
-    'avatar-click'
+    'avatar-click',
+    'context-menu-opened'
   ],
 
   data() {
@@ -602,6 +606,11 @@ export default {
       this.$nextTick(() => {
         formatWrapper.style.cssText = ''
       })
+    },
+
+    handleContextMenu(event) {
+      event.preventDefault()
+      this.$emit('context-menu-opened', { messageId: this.message._id })
     }
   }
 }


### PR DESCRIPTION
Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/289
> - :warning: Falta fazer na listagem de rooms (vou abrir outra issue para isso), pois é no `optiwork-chat`
### Descrição:
- Permite abrir o menu de ações clicando com o botão direito do mouse sobre a mensagem

### Demonstração:
https://github.com/user-attachments/assets/40f6485b-aad0-4157-b179-6cce1794e2fa

### Como testar:
- Clicar sobre a mensagem com o botão direito deve abrir o menu de ações e as ações devem funcionar normalmente.

Fix: https://github.com/optidatacloud/optiwork-chat/issues/289