### PR TITLE
redo: adjusts in visualizer colors (issue #1016)

### DIFF
--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -1,4 +1,4 @@
-const white = '#FFFFF';
+const white = '#FFFFFF';
 const grayLightest = '#F7F7F7';
 const lightGray = '#F5F5F5';
 const paleGray = '#EBEBEE';
@@ -17,7 +17,7 @@ const purple = '#905DA5';
 export const defaultThemeStyles = {
   light: {
     general: {
-      primary: '#7367f0',
+      primary: purple,
       danger: '#eb4034',
       warning: 'orange',
       color: '#0a0a0a',
@@ -180,7 +180,7 @@ export const defaultThemeStyles = {
   },
   dark: {
     general: {
-      primary: '#7367f0',
+      primary: purple,
       danger: '#eb4034',
       warning: 'orange',
       color: '#fff',


### PR DESCRIPTION
- fixes [#1016](https://github.com/optidatacloud/optiwork-chat/issues/1016)

![image](https://github.com/user-attachments/assets/3d9de3f3-c22c-42fb-b452-32c1a5d65754)
![image](https://github.com/user-attachments/assets/8866b996-09c0-4a6d-9d01-dcb472637ad0)

--- 

### 👼  Implementação:

- Ajustei as cores do visualizador do Chat (no light e no dark mode);
- Nesse pr do `vue-advanced-chat` a única coisa que foi mudada foi o tom do roxo;

---

### 🧪 Como testar:

- Os testes estão em: https://github.com/optidatacloud/optiwork-chat/pull/1023