### PR TITLE
styles: adjusts in forwarding messages bg color (issue #1036)

### DIFF
--- a/src/lib/Room/RoomMessage/RoomMessage.scss
+++ b/src/lib/Room/RoomMessage/RoomMessage.scss
@@ -342,7 +342,7 @@
         transition: all 0.25s;
 
         &.selected {
-          background-color: #2196F3;
+          background-color: #905DA5;
 
           &:after {
             left: 0.45em;


### PR DESCRIPTION
- fixes [#1036](https://github.com/optidatacloud/optiwork-chat/issues/1036)

### Dark Layout
![image](https://github.com/user-attachments/assets/e2b9fdab-3023-4415-9aff-f42bb4fff762)

### Light Layout
![image](https://github.com/user-attachments/assets/ba5bbeb1-fa49-4c54-bb19-0ac84d806a38)


--- 

### 👼  Implementação:

- Ajusta a cor da checkbox de mensagem encaminhada;

---

### 🧪 Como testar:

- Testar com https://github.com/optidatacloud/optiwork-chat/pull/1032;
- Verificar as cores do encaminhamento de mensagem estão condizentes (tanto no light quanto no dark theme);