### PR TITLE
ui: improves file ui (issue #110, pr #111)

### DIFF
--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
@@ -8,11 +8,11 @@
     background-size: cover !important;
     background-position: center center !important;
     background-repeat: no-repeat !important;
-    height: 100px;
-    width: 100px;
+    height: 90px;
+    width: 90px;
     border: var(--chat-border-style-input);
     border-radius: 4px;
-    padding: 0.3rem;
+    padding: 1rem;
   }
 
   .vac-optiwork-file {
@@ -35,9 +35,10 @@
   }
 
   .vac-file-container {
-    min-height: 80px;
-    width: 80px;
+    min-height: 90px;
+    width: 90px;
     padding: 1rem;
+    border: 1px solid #eeeeee1a;
   }
 
   .vac-icon-remove {

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
@@ -41,6 +41,12 @@
     border: 1px solid #bebec7;
   }
 
+  .vac-room-file-icon {
+    > i {
+      font-size: 30px;
+    }
+  }
+
   .vac-icon-remove {
     position: absolute;
     top: 0.25rem;

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
@@ -1,7 +1,6 @@
 .vac-room-file-container {
   display: flex;
   position: relative;
-  margin: 0 4px;
 
   .vac-message-image {
     position: relative;
@@ -13,6 +12,7 @@
     width: 100px;
     border: var(--chat-border-style-input);
     border-radius: 4px;
+    padding: 0.3rem;
   }
 
   .vac-optiwork-file {
@@ -35,14 +35,20 @@
   }
 
   .vac-file-container {
-    height: 80px;
+    min-height: 80px;
     width: 80px;
+    padding: 1rem;
   }
 
   .vac-icon-remove {
     position: absolute;
-    top: 6px;
-    left: 6px;
+    top: 0.25rem;
+
+    /*
+    * 20px is the width of the icon
+    * 0.25rem is the margin
+    */
+    left: calc(100% - 0.25rem - 20px);
     z-index: 10;
 
     svg {

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
@@ -38,7 +38,7 @@
     min-height: 90px;
     width: 90px;
     padding: 1rem;
-    border: 1px solid #eeeeee1a;
+    border: 1px solid #bebec7;
   }
 
   .vac-icon-remove {

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vac-room-file-container">
+  <div class="vac-room-file-container" :title="fileNameAndExtension">
     <loader :show="file.loading" type="room-file">
       <template v-for="(idx, name) in $slots" #[name]="data">
         <slot :name="name" v-bind="data" />
@@ -52,15 +52,13 @@
       :class="{ 'vac-blur-loading': file.loading }"
     >
       <div>
-        <slot name="file-icon">
-          <svg-icon name="file" />
-        </slot>
+        <i :class="fileIconClass" style="font-size: 25px;" />
       </div>
       <div class="vac-text-ellipsis">
         {{ file.name }}
       </div>
       <div v-if="file.extension" class="vac-text-ellipsis vac-text-extension">
-        {{ file.extension }}
+        {{ fileSizeAndExtension }}
       </div>
     </div>
   </div>
@@ -71,6 +69,7 @@ import Loader from '../../../../../components/Loader/Loader'
 import SvgIcon from '../../../../../components/SvgIcon/SvgIcon'
 
 import { isImageFile, isVideoFile } from '../../../../../utils/media-file'
+import { humanFileSize } from '../../../../../utils/data-validation'
 
 const SOURCE_OPTIWORK_DRIVE = 'SOURCE_OPTIWORK_DRIVE'
 
@@ -97,6 +96,18 @@ export default {
     },
     isFileFromOptiwork() {
       return this.file.source === SOURCE_OPTIWORK_DRIVE
+    },
+    fileIconClass() {
+      return Optidata.MimeTypeIcons.getIconByMimeType(this.file.type)
+    },
+    fileNameAndExtension() {
+      if (this.file.extension) {
+        return `${this.file.name}.${this.file.extension}`
+      }
+      return this.file.name
+    },
+    fileSizeAndExtension() {
+      return `${humanFileSize(this.file.size, true)} · ${this.file.extension}`
     }
   }
 }

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
@@ -51,8 +51,8 @@
       class="vac-file-container"
       :class="{ 'vac-blur-loading': file.loading }"
     >
-      <div>
-        <i :class="fileIconClass" style="font-size: 30px;" />
+      <div class="vac-room-file-icon">
+        <i :class="fileIconClass" />
       </div>
       <div class="vac-text-ellipsis">
         {{ file.name }}

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
@@ -52,7 +52,7 @@
       :class="{ 'vac-blur-loading': file.loading }"
     >
       <div>
-        <i :class="fileIconClass" style="font-size: 25px;" />
+        <i :class="fileIconClass" style="font-size: 30px;" />
       </div>
       <div class="vac-text-ellipsis">
         {{ file.name }}

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
@@ -69,7 +69,7 @@ import Loader from '../../../../../components/Loader/Loader'
 import SvgIcon from '../../../../../components/SvgIcon/SvgIcon'
 
 import { isImageFile, isVideoFile } from '../../../../../utils/media-file'
-import { humanFileSize } from '../../../../../utils/data-validation'
+import { humanFileSize } from '../../../../../utils/adhoc'
 
 const SOURCE_OPTIWORK_DRIVE = 'SOURCE_OPTIWORK_DRIVE'
 

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFiles.scss
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFiles.scss
@@ -1,13 +1,18 @@
 .vac-room-files-container {
   display: flex;
   align-items: center;
-  padding: 10px 6px 0 6px;
+  padding: 1rem;
   background: var(--chat-footer-bg-color);
+  overflow-x: auto;
 
   .vac-files-box {
     display: flex;
-    overflow: auto;
+    gap: 1rem;
     width: calc(100% - 30px);
+  }
+
+  .vac-file-item:last-child {
+    padding-right: 1rem;
   }
 
   video {

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFiles.vue
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFiles.vue
@@ -5,7 +5,7 @@
       class="vac-room-files-container"
     >
       <div class="vac-files-box">
-        <div v-for="(file, i) in files" :key="i">
+        <div v-for="(file, i) in files" :key="i" class="vac-file-item">
           <room-file
             :file="file"
             :index="i"

--- a/src/lib/Room/RoomFooter/RoomFooter.vue
+++ b/src/lib/Room/RoomFooter/RoomFooter.vue
@@ -752,11 +752,12 @@ export default {
 
           this.files.push({
             blob: record.blob,
-            name: `audio.${this.format}`,
+            name: `audio`,
             size: record.blob.size,
             duration: record.duration,
             type: record.blob.type,
             audio: true,
+            extension: this.format,
             localUrl: URL.createObjectURL(record.blob),
             source: SOURCE_USER_FILE_SYSTEM
           })

--- a/src/lib/Room/RoomFooter/RoomMessageReply/RoomMessageReply.scss
+++ b/src/lib/Room/RoomFooter/RoomMessageReply/RoomMessageReply.scss
@@ -46,9 +46,15 @@
     }
   }
 
+  .vac-file-container {
+    max-width: 80px;
+    flex-wrap: nowrap;
+    padding: .5rem 1rem .5rem 0;
+  }
+
   .vac-image-reply {
     max-height: 100px;
-    max-width: 200px;
+    max-width: 250px;
     margin: 4px 10px 0 0;
     border-radius: 4px;
   }
@@ -57,8 +63,28 @@
     margin-right: 10px;
   }
 
-  .vac-file-container {
-    max-width: 80px;
+  .vac-reply-file-icon {
+    display: flex;
+    justify-content: center;
+    width: 25%;
+  }
+
+  .vac-reply-file-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 75%;
+  }
+
+  .vac-reply-file-name {
+    font-weight: 500;
+    text-align: left;
+  }
+
+  .vac-reply-file-extension-and-size {
+    color: var(--chat-message-color-file-extension);
+    font-size: 12px;
+    text-align: left;
   }
 }
 

--- a/src/lib/Room/RoomFooter/RoomMessageReply/RoomMessageReply.scss
+++ b/src/lib/Room/RoomFooter/RoomMessageReply/RoomMessageReply.scss
@@ -67,6 +67,10 @@
     display: flex;
     justify-content: center;
     width: 25%;
+
+     > i {
+      font-size: 35px;
+     }
   }
 
   .vac-reply-file-info {

--- a/src/lib/Room/RoomFooter/RoomMessageReply/RoomMessageReply.vue
+++ b/src/lib/Room/RoomFooter/RoomMessageReply/RoomMessageReply.vue
@@ -40,7 +40,7 @@
 
         <div v-else-if="isOtherFile" class="vac-image-reply vac-file-container">
           <div class="vac-reply-file-icon">
-            <i :class="fileIconClass" style="font-size: 35px;" />
+            <i :class="fileIconClass" />
           </div>
           <div class="vac-reply-file-info">
             <div class="vac-text-ellipsis vac-reply-file-name">

--- a/src/lib/Room/RoomFooter/RoomMessageReply/RoomMessageReply.vue
+++ b/src/lib/Room/RoomFooter/RoomMessageReply/RoomMessageReply.vue
@@ -39,19 +39,19 @@
         </audio-player>
 
         <div v-else-if="isOtherFile" class="vac-image-reply vac-file-container">
-          <div>
-            <slot name="file-icon">
-              <svg-icon name="file" />
-            </slot>
+          <div class="vac-reply-file-icon">
+            <i :class="fileIconClass" style="font-size: 35px;" />
           </div>
-          <div class="vac-text-ellipsis">
-            {{ firstFile.name }}
-          </div>
-          <div
-            v-if="firstFile.extension"
-            class="vac-text-ellipsis vac-text-extension"
-          >
-            {{ firstFile.extension }}
+          <div class="vac-reply-file-info">
+            <div class="vac-text-ellipsis vac-reply-file-name">
+              {{ firstFile.name }}
+            </div>
+            <div
+              v-if="firstFile.extension"
+              class="vac-reply-file-extension-and-size"
+            >
+              {{ fileExtensionAndSize }}
+            </div>
           </div>
         </div>
       </div>
@@ -72,6 +72,8 @@ import SvgIcon from '../../../../components/SvgIcon/SvgIcon'
 import FormatMessage from '../../../../components/FormatMessage/FormatMessage'
 
 import AudioPlayer from '../../RoomMessage/AudioPlayer/AudioPlayer'
+
+import { humanFileSize } from '../../../../utils/adhoc'
 
 import {
   isAudioFile,
@@ -116,6 +118,12 @@ export default {
         !this.isVideo &&
         !this.isImage
       )
+    },
+    fileIconClass() {
+      return Optidata.MimeTypeIcons.getIconByMimeType(this.firstFile.type)
+    },
+    fileExtensionAndSize() {
+      return `${this.firstFile.extension} · ${humanFileSize(this.firstFile.size, true)}`
     }
   }
 }

--- a/src/lib/Room/RoomMessage/AudioPlayer/AudioControl/AudioControl.scss
+++ b/src/lib/Room/RoomMessage/AudioPlayer/AudioControl/AudioControl.scss
@@ -2,11 +2,12 @@
   display: flex;
   align-items: center;
   max-width: calc(100% - 18px);
-  margin-right: 7px;
+  margin-right: 20px;
   margin-left: 20px;
+  flex-grow: 1;
 
   .vac-player-progress {
-    width: 190px;
+    width: 100%;
 
     .vac-line-container {
       position: relative;

--- a/src/lib/Room/RoomMessage/AudioPlayer/AudioControl/AudioControl.scss
+++ b/src/lib/Room/RoomMessage/AudioPlayer/AudioControl/AudioControl.scss
@@ -8,6 +8,7 @@
 
   .vac-player-progress {
     width: 100%;
+    min-width: 190px;
 
     .vac-line-container {
       position: relative;

--- a/src/lib/Room/RoomMessage/AudioPlayer/AudioPlayer.scss
+++ b/src/lib/Room/RoomMessage/AudioPlayer/AudioPlayer.scss
@@ -1,10 +1,10 @@
 .vac-audio-player {
   display: flex;
-  margin: 8px 0 5px;
+  margin: 8px 0 8px;
 
   .vac-svg-button {
     max-width: 18px;
-    margin-left: 7px;
+    margin-left: 15px;
   }
 }
 

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.scss
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.scss
@@ -81,6 +81,10 @@
   .vac-message-download-file-icon {
     margin-left: auto;
     justify-content: end;
+
+     > i {
+      font-size: 25px;
+     }
   }
 
   .vac-message-file-info {

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.scss
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.scss
@@ -63,4 +63,37 @@
       border-radius: 4px;
     }
   }
+
+  .vac-message-file-icon,
+  .vac-message-download-file-icon {
+    max-height: unset;
+    align-items: center;
+    max-width: 15%;
+    justify-content: center;
+  }
+
+  .vac-message-download-file-icon {
+    margin-left: auto;
+    justify-content: end;
+  }
+
+  .vac-message-file-info {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 70%;
+    margin-left: 0.75rem;
+  }
+
+  .vac-text-extension-and-size {
+    color: var(--chat-message-color-file-extension);
+    font-size: 12px;
+    text-align: left;
+  }
+
+  .vac-file-name {
+    font-weight: 500;
+    text-align: left;
+  }
 }

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.scss
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.scss
@@ -64,6 +64,12 @@
     }
   }
 
+  .vac-message-file-icon {
+    > i {
+      font-size: 35px;
+    }
+  }
+
   .vac-message-file-icon,
   .vac-message-download-file-icon {
     max-height: unset;

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
@@ -79,8 +79,8 @@
       <div
         class="vac-file-container"
         :class="{ 'vac-file-container-progress': file.progress >= 0 }"
-        :title="__('View file')"
-        @click="openFile($event, 'preview')"
+        :title="isPreviewable() ? __('View file') : __('Download file')"
+        @click="openFile($event, isPreviewable() ? 'preview' : 'download')"
       >
         <div class="vac-svg-button vac-message-file-icon">
           <i :class="fileIconClass" style="font-size: 35px;" />
@@ -93,7 +93,7 @@
             {{ fileExtensionAndSize }}
           </div>
         </div>
-        <div class="vac-svg-button vac-message-download-file-icon" :title="__('Download')" @click="openFile($event, 'download')">
+        <div class="vac-svg-button vac-message-download-file-icon" :title="__('Download file')" @click="openFile($event, 'download')">
           <i class="bi bi-download" style="font-size: 25px;" />
         </div>
       </div>

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
@@ -94,7 +94,7 @@
           </div>
         </div>
         <div class="vac-svg-button vac-message-download-file-icon" :title="__('Download file')" @click="openFile($event, 'download')">
-          <i class="bi bi-download" style="font-size: 25px;" />
+          <i class="bi bi-download" />
         </div>
       </div>
     </div>

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
@@ -175,7 +175,6 @@ export default {
     file: {
       immediate: true,
       handler() {
-        console.log('file', this.file)
         this.checkImgLoad()
       }
     }

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
@@ -105,7 +105,7 @@
 import Loader from '../../../../../components/Loader/Loader'
 import ProgressBar from '../../../../../components/ProgressBar/ProgressBar'
 import SvgIcon from '../../../../../components/SvgIcon/SvgIcon'
-import { humanFileSize } from '../../../../../utils/data-validation'
+import { humanFileSize } from '../../../../../utils/adhoc'
 import {translate} from '../../../../../utils/i18n'
 
 import { isImageFile, isVideoFile, isTextFile, isPdfFile, isSVGFile } from '../../../../../utils/media-file'

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
@@ -79,21 +79,22 @@
       <div
         class="vac-file-container"
         :class="{ 'vac-file-container-progress': file.progress >= 0 }"
-        @click="openFile($event, isPreviewable() ? 'preview' : 'download')"
+        :title="__('View file')"
+        @click="openFile($event, 'preview')"
       >
-        <div class="vac-svg-button">
-          <slot v-if="isPreviewable()" name="file-icon">
-            <svg-icon name="file" />
-          </slot>
-          <slot v-else name="document-icon">
-            <svg-icon name="document" />
-          </slot>
+        <div class="vac-svg-button vac-message-file-icon">
+          <i :class="fileIconClass" style="font-size: 35px;" />
         </div>
-        <div class="vac-text-ellipsis">
-          {{ file.name }}
+        <div class="vac-message-file-info">
+          <div class="vac-text-ellipsis vac-file-name">
+            {{ fileNameAndExtension }}
+          </div>
+          <div class="vac-text-ellipsis vac-text-extension-and-size">
+            {{ fileExtensionAndSize }}
+          </div>
         </div>
-        <div v-if="file.extension" class="vac-text-ellipsis vac-text-extension">
-          {{ file.extension }}
+        <div class="vac-svg-button vac-message-download-file-icon" :title="__('Download')" @click="openFile($event, 'download')">
+          <i class="bi bi-download" style="font-size: 25px;" />
         </div>
       </div>
     </div>
@@ -104,6 +105,8 @@
 import Loader from '../../../../../components/Loader/Loader'
 import ProgressBar from '../../../../../components/ProgressBar/ProgressBar'
 import SvgIcon from '../../../../../components/SvgIcon/SvgIcon'
+import { humanFileSize } from '../../../../../utils/data-validation'
+import {translate} from '../../../../../utils/i18n'
 
 import { isImageFile, isVideoFile, isTextFile, isPdfFile, isSVGFile } from '../../../../../utils/media-file'
 
@@ -147,6 +150,24 @@ export default {
     },
     isSVG() {
       return isSVGFile(this.file)
+    },
+    fileIconClass() {
+      return Optidata.MimeTypeIcons.getIconByMimeType(this.file.type)
+    },
+    fileNameAndExtension() {
+      if (!this.file.extension) {
+        return this.file.name
+      }
+      if (this.file.name.endsWith(`.${this.file.extension}`)) {
+        return this.file.name
+      }
+      return `${this.file.name}.${this.file.extension}`
+    },
+    fileExtensionAndSize() {
+      if (!this.file.extension) {
+        return humanFileSize(this.file.size, true)
+      }
+      return `${this.file.extension} · ${humanFileSize(this.file.size, true)}`
     }
   },
 
@@ -154,6 +175,7 @@ export default {
     file: {
       immediate: true,
       handler() {
+        console.log('file', this.file)
         this.checkImgLoad()
       }
     }
@@ -174,6 +196,9 @@ export default {
     isPreviewable() {
       return this.isText || this.isPdf || this.isSVG
     },
+    __(key) {
+      return translate(key)
+    },
     checkImgLoad() {
       if (!isImageFile(this.file)) return
       this.imageLoading = true
@@ -184,7 +209,7 @@ export default {
     openFile(event, action) {
       if (!this.messageSelectionEnabled) {
         event.stopPropagation()
-        this.$emit('open-file', { file: this.file, 'action': action })
+        this.$emit('open-file', { file: this.file, action })
       }
     }
   }

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
@@ -83,7 +83,7 @@
         @click="openFile($event, isPreviewable() ? 'preview' : 'download')"
       >
         <div class="vac-svg-button vac-message-file-icon">
-          <i :class="fileIconClass" style="font-size: 35px;" />
+          <i :class="fileIconClass" />
         </div>
         <div class="vac-message-file-info">
           <div class="vac-text-ellipsis vac-file-name">

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFiles.scss
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFiles.scss
@@ -7,10 +7,11 @@
 
     .vac-file-container {
       height: 60px;
-      max-width: 250px;
-      margin: auto;
       cursor: pointer;
       transition: all 0.6s;
+      padding: 0.25rem 1.125rem;
+      justify-content: start;
+      flex-wrap: nowrap;
 
       &:hover {
         opacity: 0.85;

--- a/src/lib/Room/RoomMessage/MessageReply/MessageReply.scss
+++ b/src/lib/Room/RoomMessage/MessageReply/MessageReply.scss
@@ -1,8 +1,9 @@
 .vac-reply-message {
-  background: var(--chat-message-bg-color-reply);
+  background: var(--chat-footer-bg-color-reply);
   border-radius: 4px;
   margin: -1px -5px 8px;
   padding: 8px 10px;
+  min-width: 190px;
 
   user-select: none;
     cursor: pointer;
@@ -55,6 +56,32 @@
 
   .vac-file-container {
     height: 60px;
-    width: 60px;
+    flex-wrap: nowrap;
+    justify-content: start;
+    padding: 0 1rem;
+  }
+
+  .vac-reply-file-icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-right: 0.75rem;
+  }
+
+  .vac-reply-file-info {
+    width: 75%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: left;
+  }
+
+  .vac-reply-file-name {
+    font-weight: 500;
+  }
+
+  .vac-file-extension-and-size {
+    color: var(--chat-message-color-file-extension);
+    font-size: 12px;
   }
 }

--- a/src/lib/Room/RoomMessage/MessageReply/MessageReply.scss
+++ b/src/lib/Room/RoomMessage/MessageReply/MessageReply.scss
@@ -66,6 +66,10 @@
     justify-content: center;
     align-items: center;
     padding-right: 0.75rem;
+
+    > i {
+      font-size: 30px;
+    }
   }
 
   .vac-reply-file-info {

--- a/src/lib/Room/RoomMessage/MessageReply/MessageReply.vue
+++ b/src/lib/Room/RoomMessage/MessageReply/MessageReply.vue
@@ -32,19 +32,18 @@
     </audio-player>
 
     <div v-else-if="isOtherFile" class="vac-file-container">
-      <div>
-        <slot name="file-icon">
-          <svg-icon name="file" />
-        </slot>
+      <div class="vac-reply-file-icon">
+        <i :class="fileIconClass" style="font-size: 30px;" />
       </div>
-      <div class="vac-text-ellipsis">
-        {{ firstFile.name }}
-      </div>
-      <div
-        v-if="firstFile.extension"
-        class="vac-text-ellipsis vac-text-extension"
-      >
-        {{ firstFile.extension }}
+      <div class="vac-reply-file-info">
+        <div class="vac-text-ellipsis vac-reply-file-name">
+          {{ firstFile.name }}
+        </div>
+        <div
+          class="vac-text-ellipsis vac-file-extension-and-size"
+        >
+          {{ fileExtensionAndSize }}
+        </div>
       </div>
     </div>
 
@@ -62,7 +61,6 @@
 </template>
 
 <script>
-import SvgIcon from '../../../../components/SvgIcon/SvgIcon'
 import FormatMessage from '../../../../components/FormatMessage/FormatMessage'
 
 import AudioPlayer from '../AudioPlayer/AudioPlayer'
@@ -73,9 +71,11 @@ import {
   isVideoFile
 } from '../../../../utils/media-file'
 
+import { humanFileSize } from '../../../../utils/adhoc'
+
 export default {
   name: 'MessageReply',
-  components: { AudioPlayer, SvgIcon, FormatMessage },
+  components: { AudioPlayer, FormatMessage },
 
   props: {
     message: { type: Object, required: true },
@@ -111,6 +111,12 @@ export default {
         !this.isVideo &&
         !this.isImage
       )
+    },
+    fileIconClass() {
+      return Optidata.MimeTypeIcons.getIconByMimeType(this.firstFile.type)
+    },
+    fileExtensionAndSize() {
+      return `${this.firstFile.extension} · ${humanFileSize(this.firstFile.size, true)}`
     }
   }
 }

--- a/src/lib/Room/RoomMessage/MessageReply/MessageReply.vue
+++ b/src/lib/Room/RoomMessage/MessageReply/MessageReply.vue
@@ -33,7 +33,7 @@
 
     <div v-else-if="isOtherFile" class="vac-file-container">
       <div class="vac-reply-file-icon">
-        <i :class="fileIconClass" style="font-size: 30px;" />
+        <i :class="fileIconClass" />
       </div>
       <div class="vac-reply-file-info">
         <div class="vac-text-ellipsis vac-reply-file-name">

--- a/src/lib/Room/RoomMessage/RoomMessage.scss
+++ b/src/lib/Room/RoomMessage/RoomMessage.scss
@@ -202,6 +202,7 @@
     display: flex;
     align-items: center;
     justify-content: end;
+    padding: 0.17rem;
   }
 
   .vac-progress-time {

--- a/src/utils/adhoc.js
+++ b/src/utils/adhoc.js
@@ -1,15 +1,15 @@
 export function humanFileSize(bytes, si = false, dp = 1) {
-  const thresh = si ? 1000 : 1024
+  const thresh = si ? 1000 : 1024;
   const units = si
     ? ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-    : ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+    : ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
 
   if (bytes < thresh) {
-    return (bytes || 0) + ' ' + units[0]
+    return (bytes || 0) + ' ' + units[0];
   }
 
-  const u = Math.floor(Math.log(bytes) / Math.log(thresh))
-  const size = (bytes / Math.pow(thresh, u)).toFixed(dp)
+  const u = Math.floor(Math.log(bytes) / Math.log(thresh));
+  const size = (bytes / Math.pow(thresh, u)).toFixed(dp);
 
-  return (size || 0) + ' ' + units[u]
+  return (size || 0) + ' ' + units[u];
 }

--- a/src/utils/adhoc.js
+++ b/src/utils/adhoc.js
@@ -1,0 +1,15 @@
+export function humanFileSize(bytes, si = false, dp = 1) {
+  const thresh = si ? 1000 : 1024
+  const units = si
+    ? ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    : ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+
+  if (bytes < thresh) {
+    return (bytes || 0) + ' ' + units[0]
+  }
+
+  const u = Math.floor(Math.log(bytes) / Math.log(thresh))
+  const size = (bytes / Math.pow(thresh, u)).toFixed(dp)
+
+  return (size || 0) + ' ' + units[u]
+}

--- a/src/utils/data-validation.js
+++ b/src/utils/data-validation.js
@@ -73,3 +73,19 @@ function checkObjectValid(obj, key) {
     obj[key] !== undefined
   )
 }
+
+export function humanFileSize(bytes, si = false, dp = 1) {
+  const thresh = si ? 1000 : 1024
+  const units = si
+    ? ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    : ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+
+  if (bytes < thresh) {
+    return (bytes || 0) + ' ' + units[0]
+  }
+
+  const u = Math.floor(Math.log(bytes) / Math.log(thresh))
+  const size = (bytes / Math.pow(thresh, u)).toFixed(dp)
+
+  return (size || 0) + ' ' + units[u]
+}

--- a/src/utils/data-validation.js
+++ b/src/utils/data-validation.js
@@ -73,19 +73,3 @@ function checkObjectValid(obj, key) {
     obj[key] !== undefined
   )
 }
-
-export function humanFileSize(bytes, si = false, dp = 1) {
-  const thresh = si ? 1000 : 1024
-  const units = si
-    ? ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-    : ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
-
-  if (bytes < thresh) {
-    return (bytes || 0) + ' ' + units[0]
-  }
-
-  const u = Math.floor(Math.log(bytes) / Math.log(thresh))
-  const size = (bytes / Math.pow(thresh, u)).toFixed(dp)
-
-  return (size || 0) + ' ' + units[u]
-}


### PR DESCRIPTION
### Descrição 📝 
* Ajusta UI dos arquivos para que seja mostrado o nome, tipo do arquivo, tamanho e ícone conforme tipo (ver prévia);
* Isso foi ajustado nos componentes onde um arquivo aparece: na mensagem, ao anexar e na resposta de mensagem;
* fix #110;

### Prévia 👀 
* Modo claro:
![image](https://github.com/user-attachments/assets/1df54e2c-1908-488b-a6fd-c14b3fc855cc)

* Modo escuro:
![image](https://github.com/user-attachments/assets/0cb5f932-02fb-478a-91e3-5d844c90905e)

### Como testar 🐛 
* Testar no pull request do Chat: https://github.com/optidatacloud/optiwork-chat/pull/1066;