### PR TITLE
chore: disables file viewer (issue #112, pr #113)

### DIFF
--- a/src/lib/ChatWindow.vue
+++ b/src/lib/ChatWindow.vue
@@ -642,14 +642,7 @@ export default {
     openFile(event) {
       const file = typeof event?.files !== 'undefined' ? event?.files[event.index] : event.file
       const message = event.message
-
-      if (this.mediaPreviewEnabledCasted && event.action === 'preview') {
-        this.previewFiles = event.files ?? [ file ]
-        this.previewIndex = event.index ?? 0
-        this.showMediaPreview = true
-      } else {
-        this.$emit('open-file', { message, file: file, action: event.action })
-      }
+      this.$emit('open-file', { message, file: file, action: event.action })
     },
     openUserTag({ user }) {
       this.$emit('open-user-tag', { user })

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.scss
@@ -15,25 +15,6 @@
     padding: 1rem;
   }
 
-  .vac-optiwork-file {
-    @extend .vac-message-image;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    padding: 5px;
-  }
-
-  .vac-optiwork-file-icon {
-    font-size: 30px;
-  }
-
-  .vac-optiwork-file-name {
-    font-size: smaller;
-    text-align: center;
-    color: #3b3b3b;
-  }
-
   .vac-file-container {
     min-height: 90px;
     width: 90px;

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
@@ -17,15 +17,17 @@
 
     <div
       v-if="isFileFromOptiwork"
-      class="vac-optiwork-file"
+      class="vac-file-container"
       :title="file.name"
     >
-      <div>
-        <i :class="file.icon" class="vac-optiwork-file-icon" />
+      <div class="vac-room-file-icon">
+        <i :class="fileIconClass" />
       </div>
-
-      <div class="vac-optiwork-file-name vac-text-ellipsis">
+      <div class="vac-text-ellipsis">
         {{ file.name }}
+      </div>
+      <div class="vac-text-ellipsis vac-text-extension">
+        {{ fileSizeAndExtension }}
       </div>
     </div>
 
@@ -57,7 +59,7 @@
       <div class="vac-text-ellipsis">
         {{ file.name }}
       </div>
-      <div v-if="file.extension" class="vac-text-ellipsis vac-text-extension">
+      <div class="vac-text-ellipsis vac-text-extension">
         {{ fileSizeAndExtension }}
       </div>
     </div>
@@ -107,6 +109,9 @@ export default {
       return this.file.name
     },
     fileSizeAndExtension() {
+      if (!this.file.extension) {
+        return humanFileSize(this.file.size, true)
+      }
       return `${humanFileSize(this.file.size, true)} · ${this.file.extension}`
     }
   }

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
@@ -6,7 +6,7 @@
       class="vac-message-image-container"
       @mouseover="imageHover = true"
       @mouseleave="imageHover = false"
-      @click.prevent.stop="openFile($event, 'preview')"
+      @click.prevent.stop="openFile($event, 'view')"
     >
       <progress-bar
         v-if="file.progress >= 0"
@@ -44,7 +44,7 @@
           >
             <div
               class="vac-svg-button vac-button-view"
-              @click.prevent.stop="openFile($event, 'preview')"
+              @click.prevent.stop="openFile($event, 'view')"
             >
               <slot :name="'eye-icon_' + message._id">
                 <svg-icon name="eye" />
@@ -66,7 +66,7 @@
     <div
       v-else-if="isVideo"
       class="vac-video-container"
-      @click.prevent="openFile($event, 'preview')"
+      @click.prevent="openFile($event, 'view')"
     >
       <progress-bar v-if="file.progress >= 0" :progress="file.progress" />
       <video controls>
@@ -79,8 +79,8 @@
       <div
         class="vac-file-container"
         :class="{ 'vac-file-container-progress': file.progress >= 0 }"
-        :title="isPreviewable() ? __('View file') : __('Download file')"
-        @click="openFile($event, isPreviewable() ? 'preview' : 'download')"
+        :title="__('View file')"
+        @click="openFile($event, 'view')"
       >
         <div class="vac-svg-button vac-message-file-icon">
           <i :class="fileIconClass" />
@@ -192,9 +192,6 @@ export default {
   },
 
   methods: {
-    isPreviewable() {
-      return this.isText || this.isPdf || this.isSVG
-    },
     __(key) {
       return translate(key)
     },

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFiles.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFiles.vue
@@ -7,7 +7,7 @@
         :message="message"
         :index="i"
         :message-selection-enabled="messageSelectionEnabled"
-        @open-file="$emit('open-file', { index: i, files: allFiles, action: $event?.action ?? 'preview' })"
+        @open-file="$emit('open-file', { index: i, files: allFiles, action: $event?.action ?? 'view' })"
       >
         <template v-for="(idx, name) in $slots" #[name]>
           <slot :name="name" />


### PR DESCRIPTION
### Descrição 📝 
* Ajusta para desabilitar o visualizador de arquivos do VAC visto que vamos usar o visualizador do Drive (🔝);
* Antes o VAC tinha um tratamento para arquivos `previewable` (`pdf` e `images`), removi esse trecho e propaguei o evento pro Chat (agora é ele que vai tratar esse fluxo);
* O Chat escuta esse arquivo e trata ele conforme a ação enviada (`view` ou `download`);
* Ajustei também a UI da lista de arquivos anexados do Drive (antes a lista desse tipo de arquivo não mostrava o tamanho e o tipo);
* fix #112;

### Prévia 👀 
#### Lista de arquivos anexados do Drive

* Antes:
![image](https://github.com/user-attachments/assets/ec33e557-80bc-4aaf-b4a1-4f5328b0f0f0)

* Depois:
![image](https://github.com/user-attachments/assets/a0d4682f-f66e-4c88-8791-66ca03bcedf4)

### Como testar 🐛 
* Anexar arquivos do Drive;
* Verificar se o arquivo anexado irá mostrar o tipo e o tamanho (ver prévia);