### PR TITLE
fix: file view error package (issue #1072)

### DIFF
--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
@@ -197,6 +197,10 @@ export default {
       image.addEventListener('load', () => (this.imageLoading = false))
     },
     openFile(event, action) {
+      if (!this.message.distributed) {
+        return
+      }
+
       if (!this.messageSelectionEnabled) {
         event.stopPropagation()
         this.$emit('open-file', { file: this.file, action })


### PR DESCRIPTION
### 📝 Descrição:

Este PR evita a exibição da tela de erro ao tentar abrir um documento antes que ele esteja completamente preparado para visualização ou download. Apliquei a mesma lógica usada no controle de envio de mensagens para garantir consistência na interface.

Agora, enquanto a mensagem exibe um único check (✅), o documento permanecerá inacessível. Assim que a mensagem for enviada e receber o double check (✅✅), o documento poderá ser baixado ou visualizado normalmente.

---

### 🧪 Como testar:

Reproduza o comportamento reportado na issue.

Verifique que os botões de visualizar/download só ficam disponíveis após os arquivos estarem prontos.

---

- Fix: https://github.com/optidatacloud/optiwork-chat/issues/1072