### PR TITLE
tweak: forward button styling (issue #1190)

### DIFF
--- a/src/lib/Room/RoomHeader/RoomHeader.scss
+++ b/src/lib/Room/RoomHeader/RoomHeader.scss
@@ -88,16 +88,27 @@
         color: var(--chat-message-color-forwarded);
       }
 
-      .vac-selection-count-container{
+      .vac-selection-count-container {
         margin-left:14px;
         font-size: 14.5px;
-        color: var(--chat-message-color-forwarded);;
+        color: var(--chat-message-color-forwarded);
         user-select: none;
         margin-top: 2px;
       }
     }
-    .forward-messages{
-      color: var(--chat-message-color-forwarded);;
+    .forward-messages {
+      button {
+        background-color: var(--bs-primary);
+        border: 0;
+        border-radius: 6px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        padding: 8px 12px;
+        color: white;
+        cursor: pointer;
+      }
     }
   }
 

--- a/src/lib/Room/RoomHeader/RoomHeader.vue
+++ b/src/lib/Room/RoomHeader/RoomHeader.vue
@@ -15,9 +15,9 @@
               </span>
 
               <div class="vac-selection-count-container">
-               <span class="vac-selection-button-count">
+                <span class="vac-selection-button-count">
                   {{ selectedMessagesTotal }}
-               </span>
+                </span>
                 {{ textMessages.COUNT_SELECT_MESSAGE }}
               </div>
             </div>
@@ -27,11 +27,13 @@
               :key="action.name"
             >
               <div v-if="action.name === 'forwardMessages'" class="vac-item-clickable forward-messages" :title="action.title" @click="messageSelectionActionHandler(action)">
-                  <span>
-                    <svg viewBox="0 0 24 24" height="24" width="24" preserveAspectRatio="xMidYMid meet" class="" version="1.1" x="0px" y="0px" enable-background="new 0 0 24 24" xml:space="preserve">
-                      <path fill="currentColor" d="M14.278,4.813c0-0.723,0.873-1.085,1.383-0.574l6.045,6.051 c0.317,0.317,0.317,0.829,0,1.146l-6.045,6.051c-0.51,0.51-1.383,0.149-1.383-0.574v-2.732c-5.096,0-8.829,1.455-11.604,4.611 c-0.246,0.279-0.702,0.042-0.602-0.316C3.502,13.303,6.997,8.472,14.278,7.431V4.813z" />
+                  <button>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-send-icon lucide-send">
+                      <path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/>
+                      <path d="m21.854 2.147-10.94 10.939"/>
                     </svg>
-                  </span>
+                    <span>{{ translate('Forward') }}</span>
+                  </button>
               </div>
 
               <div


### PR DESCRIPTION
Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/1190

## Descrição
- Esse PR altera a estilização do botão de encaminhar mensagens para ficar padronizado com o restante do Optiwork

## Capturas

| Antes | Depois |
|  ---  |  ---   |
| ![image](https://github.com/user-attachments/assets/cdc99b01-a355-4213-840a-40df404ce940) | ![image](https://github.com/user-attachments/assets/99fa3d3c-4023-44a9-b030-3f7fd2150666) |
| ![image](https://github.com/user-attachments/assets/9c24b702-0589-47bb-bf54-93f17a7bd04e) | ![image](https://github.com/user-attachments/assets/8723ef39-c715-4706-8113-54f39aa52d77) |
## Como testar
- Verificar se o botão de encaminhar continua funcionando normalmente

Fix: https://github.com/optidatacloud/optiwork-chat/issues/1190
