### PR TITLE
redo: fix username display

### DIFF
--- a/src/lib/Room/RoomMessage/RoomMessage.vue
+++ b/src/lib/Room/RoomMessage/RoomMessage.vue
@@ -155,7 +155,7 @@
 
                 <!-- show phone or email -->
                 <span v-if="hasWhatsappIntegration" class="vac-username-info">
-                  {{ isWhatsappGroupFeatureEnabled && isMessageFromWhatsapp(message) ? message.user?.whatsapp_info.phone_number_formatted : message.user.email }}
+                  {{ isWhatsappGroupFeatureEnabled && isMessageFromWhatsapp(message) ? message.user?.whatsapp_info.phone_number_formatted : message.user?.email }}
                 </span>
 
                 <!-- logo whatsapp or optiwork -->

--- a/src/lib/Room/RoomMessage/RoomMessage.vue
+++ b/src/lib/Room/RoomMessage/RoomMessage.vue
@@ -150,12 +150,12 @@
                     ? (isMessageFromWhatsapp(message) ? 'color: limegreen;' : 'color: #905DA5;')
                     : ''"
                 >
-                  {{ hasWhatsappIntegration ? message.user.name : `${message.user.name} <${message.user.email}>` }}
+                  {{ message.username }}
                 </span>
 
                 <!-- show phone or email -->
                 <span v-if="hasWhatsappIntegration" class="vac-username-info">
-                  {{ isWhatsappGroupFeatureEnabled && isMessageFromWhatsapp(message) ? message.user?.whatsapp_info.phone_number_formatted : message.user?.email }}
+                  {{ isWhatsappGroupFeatureEnabled && isMessageFromWhatsapp(message) ? message.user?.whatsapp_info.phone_number_formatted : message.user.email }}
                 </span>
 
                 <!-- logo whatsapp or optiwork -->


### PR DESCRIPTION
## Descrição
- Esse PR ajusta para que o nome seja buscado do lugar correto em grupos sem integração com o Whatsapp.

## Como testar
- Mensagens e arquivos devem corretamente ser exibidas entre dois usuários
