### PR TITLE
tweak: convert avatar to img tag (issue #114)

### DIFF
--- a/src/lib/Room/RoomFooter/RoomUsersTag/RoomUsersTag.vue
+++ b/src/lib/Room/RoomFooter/RoomUsersTag/RoomUsersTag.vue
@@ -10,11 +10,7 @@
         @click="$emit('select-user-tag', user)"
       >
         <div class="vac-tags-info">
-          <div
-            v-if="user.avatar"
-            class="vac-avatar vac-tags-avatar"
-            :style="{ 'background-image': `url('${user.avatar}')` }"
-          />
+          <img v-show="user.avatar" :src="user.avatar" class="vac-avatar vac-tags-avatar" />
           <div class="vac-tags-username">
             {{ user.username }}
           </div>

--- a/src/lib/Room/RoomHeader/RoomHeader.vue
+++ b/src/lib/Room/RoomHeader/RoomHeader.vue
@@ -68,11 +68,7 @@
             @click="$emit('room-info')"
           >
             <slot name="room-header-avatar">
-              <div
-                v-if="room.avatar"
-                class="vac-avatar"
-                :style="{ 'background-image': `url('${room.avatar}')` }"
-              />
+              <img v-show="room.avatar" :src="room.avatar" class="vac-avatar" />
             </slot>
             <slot name="room-header-info">
               <div class="vac-text-ellipsis">

--- a/src/lib/Room/RoomMessage/RoomMessage.vue
+++ b/src/lib/Room/RoomMessage/RoomMessage.vue
@@ -106,13 +106,7 @@
             v-if="message.senderId !== currentUserId"
             :name="'message-avatar_' + message._id"
           >
-            <div
-              v-if="message.avatar && !messageSelectionEnabled"
-              class="vac-avatar"
-              style="cursor: pointer"
-              :style="{ 'background-image': `url('${message.avatar}')` }"
-              @click="onMessageAvatarClicked(message)"
-            />
+            <img v-show="message.avatar && !messageSelectionEnabled" :src="message.avatar" @click="onMessageAvatarClicked(message)" class="vac-avatar cursor-pointer" />
           </slot>
           <div
             v-if="hasSenderUserAvatar && !message.avatar"
@@ -315,11 +309,7 @@
             v-if="message.senderId === currentUserId"
             :name="'message-avatar_' + message._id"
           >
-            <div
-              v-if="message.avatar && !messageSelectionEnabled"
-              class="vac-avatar vac-avatar-current"
-              :style="{ 'background-image': `url('${message.avatar}')` }"
-            />
+            <img v-show="message.avatar && !messageSelectionEnabled" :src="message.avatar" class="vac-avatar vac-avatar-current" />
           </slot>
           <div
             v-if="hasCurrentUserAvatar && !message.avatar"

--- a/src/lib/RoomsList/RoomCallContent/RoomCallContent.vue
+++ b/src/lib/RoomsList/RoomCallContent/RoomCallContent.vue
@@ -3,7 +3,7 @@
     <div class="vac-room-info-container">
       <slot :name="'room-list-item_' + room.roomId">
         <slot :name="'room-list-avatar_' + room.roomId">
-          <div v-if="room.avatar" class="vac-avatar" :style="{ 'background-image': `url('${room.avatar}')` }" />
+          <img v-show="room.avatar" :src="room.avatar" class="vac-avatar" />
         </slot>
       </slot>
 

--- a/src/lib/RoomsList/RoomContent/RoomContent.vue
+++ b/src/lib/RoomsList/RoomContent/RoomContent.vue
@@ -2,11 +2,7 @@
   <div class="vac-room-container">
     <slot :name="'room-list-item_' + room.roomId">
       <slot :name="'room-list-avatar_' + room.roomId">
-        <div
-          v-if="room.avatar"
-          class="vac-avatar"
-          :style="{ 'background-image': `url('${room.avatar}')` }"
-        />
+        <img v-show="room.avatar" :src="room.avatar" class="vac-avatar" />
       </slot>
       <div class="vac-name-container vac-text-ellipsis">
         <div class="vac-title-container">

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
 			output: {
 				globals: {
 					vue: 'Vue',
+					pinia: 'Pinia',
 					Optidata: 'Optidata'
 				}
 			},


### PR DESCRIPTION
Resolve:
> - #114 

## Descrição
- Esse PR ajusta para que as imagens de avatar sejam exibidas usando uma tag `img` em vez de usar `backgroud-image: url(...)`, assim vamos poder fazer cache da foto de perfil do usuário e do avatar do grupo.

## Como testar
- Verificar todas as ocorrências de avatar de usuário/grupo e confirmar se estão todas sendo exibidas corretamente, posicionamento/alinhamento/distorção etc. A princípio tudo deve ter ficado inalterado na visão do usuário.

- Cabeçalho do chat (grupo/invidual)
![image](https://github.com/user-attachments/assets/8e90a8e2-dafa-49e3-afe8-e11bc39a53dd)

- Menu de menções
![image](https://github.com/user-attachments/assets/410b0330-65b9-4048-8f4b-6a63da645652)

- Ao lado da mensagem (minha e de outros)
![image](https://github.com/user-attachments/assets/8b06acb6-7b19-4fc1-844e-6d50fe0bc67b)

- Listagem de conversas
![image](https://github.com/user-attachments/assets/23c08e04-7d15-4e17-817a-8045eb7fe20c)

- :warning: Também foi modificado um ícone de usuário relacionado às chamadas

Fix: #114 