### PR TITLE
redo: message username text overflow (issue #1158)

### DIFF
--- a/src/lib/Room/RoomMessage/RoomMessage.scss
+++ b/src/lib/Room/RoomMessage/RoomMessage.scss
@@ -182,10 +182,11 @@
     font-size: 13px;
     font-weight: 600;
     color: var(--chat-message-color-username);
-    margin-bottom: 2px;
+    margin-bottom: 4px;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    gap: 8px;
+    gap: 2px 8px;
 
     .vac-username-info {
       font-weight: normal;


### PR DESCRIPTION
Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/1158

## Descrição
- Esse PR ajusta um overflow no username em telas de tamanho reduzido.

## Capturas

| Antes | Depois |
| ---   |  ----  |
| ![image](https://github.com/user-attachments/assets/945d858f-8681-457f-82fc-c0029081f73a) | ![image](https://github.com/user-attachments/assets/a1289436-7f48-4242-8eea-4277cb78a536) |


Fix: https://github.com/optidatacloud/optiwork-chat/issues/1158