### PR TITLE
redo: fix avatar stretching (issue #114)

### DIFF
--- a/src/lib/Room/RoomFooter/RoomFooter.vue
+++ b/src/lib/Room/RoomFooter/RoomFooter.vue
@@ -94,7 +94,7 @@
 
         <div class="vac-dot-audio-record" />
 
-        <div class="vac-dot-audio-record-time">
+        <div class="vac-dot-audio-record-time" style="text-wrap: nowrap;">
           {{ recordedTime }}
         </div>
 
@@ -109,7 +109,7 @@
       </div>
 
       <textarea
-        v-if="!isRecording"
+        v-show="!isRecording"
         id="roomTextarea"
         ref="roomTextarea"
         :placeholder="textareaHighlight ? textMessages.TYPE_HIGHLIGHT_MESSAGE: textMessages.TYPE_MESSAGE"
@@ -1020,6 +1020,7 @@ export default {
       }
     },
     resetMessage(disableMobileFocus = false, initRoom = false) {
+      console.log('resetMessage')
       this.setFilePickerState('all')
       if (!initRoom) {
         this.$emit('typing-message', null)
@@ -1050,6 +1051,7 @@ export default {
       if (this.keepKeyboardOpen) this.getTextareaRef().focus()
     },
     initRecorder() {
+      console.log('initRecorder')
       this.isRecording = false
 
       return new Recorder({
@@ -1062,6 +1064,7 @@ export default {
       })
     },
     micFailed() {
+      console.log('micFailed')
       this.isRecording = false
       this.recorder = this.initRecorder()
     }

--- a/src/lib/Room/RoomFooter/RoomFooter.vue
+++ b/src/lib/Room/RoomFooter/RoomFooter.vue
@@ -1020,7 +1020,6 @@ export default {
       }
     },
     resetMessage(disableMobileFocus = false, initRoom = false) {
-      console.log('resetMessage')
       this.setFilePickerState('all')
       if (!initRoom) {
         this.$emit('typing-message', null)
@@ -1051,7 +1050,6 @@ export default {
       if (this.keepKeyboardOpen) this.getTextareaRef().focus()
     },
     initRecorder() {
-      console.log('initRecorder')
       this.isRecording = false
 
       return new Recorder({
@@ -1064,7 +1062,6 @@ export default {
       })
     },
     micFailed() {
-      console.log('micFailed')
       this.isRecording = false
       this.recorder = this.initRecorder()
     }

--- a/src/lib/Room/RoomFooter/RoomUsersTag/RoomUsersTag.scss
+++ b/src/lib/Room/RoomFooter/RoomUsersTag/RoomUsersTag.scss
@@ -26,6 +26,7 @@
   }
 
   .vac-tags-avatar {
+    object-fit: cover;
     height: 34px;
     width: 34px;
     min-height: 34px;

--- a/src/lib/Room/RoomHeader/RoomHeader.scss
+++ b/src/lib/Room/RoomHeader/RoomHeader.scss
@@ -148,6 +148,7 @@
     }
 
     .vac-avatar {
+      object-fit: cover;
       height: 37px;
       width: 37px;
       min-height: 37px;

--- a/src/lib/Room/RoomMessage/RoomMessage.scss
+++ b/src/lib/Room/RoomMessage/RoomMessage.scss
@@ -61,6 +61,7 @@
   $avatar-size: 28px;
 
   .vac-avatar {
+    object-fit: cover;
     height: $avatar-size;
     width: $avatar-size;
     min-height: $avatar-size;


### PR DESCRIPTION
Resolve:
> - #114 

## Descrição
- Esse ajusta um erro onde os avatares ficavam esticados


## Como testar
- Mesmo de https://github.com/optidatacloud/vue-advanced-chat/pull/123


Fix: #114