### PR TITLE
refact/perf: replace background-image with img tag (issue #1174)

### DIFF
--- a/src/components/FormatMessage/FormatMessage.vue
+++ b/src/components/FormatMessage/FormatMessage.vue
@@ -44,13 +44,7 @@
           </template>
           <template v-else-if="message.url && message.image">
             <div class="vac-image-link-container">
-              <div
-                class="vac-image-link"
-                :style="{
-                  'background-image': `url('${message.value}')`,
-                  height: message.height
-                }"
-              />
+              <img :src="message.value" class="vac-image-link" :style="{ height: message.height }" />
             </div>
             <div class="vac-image-link-message">
               {{ message.value }}

--- a/src/lib/MediaPreview/MediaPreview.vue
+++ b/src/lib/MediaPreview/MediaPreview.vue
@@ -12,7 +12,7 @@
         <div v-if="!isSVGLoading" v-html="fileContent" />
         <loader v-else show="true" type="messages" />
       </div>
-      <div v-else class="vac-image-preview" :style="{ 'background-image': `url('${file.url}')` }" />
+      <img v-else :src="file.url" class="vac-image-preview" />
     </div>
 
     <div v-else-if="isVideo" class="vac-media-preview-container">

--- a/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
+++ b/src/lib/Room/RoomFooter/RoomFiles/RoomFile/RoomFile.vue
@@ -31,13 +31,11 @@
       </div>
     </div>
 
-    <div
+    <img
       v-else-if="isImage"
       class="vac-message-image"
       :class="{ 'vac-blur-loading': file.loading }"
-      :style="{
-        'background-image': `url('${file.localUrl || file.url}')`
-      }"
+      :src="file.localUrl || file.url"
     />
 
     <video

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.scss
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.scss
@@ -11,6 +11,7 @@
   }
 
   .vac-image-buttons {
+    top: -10px;
     position: absolute;
     width: 100%;
     height: 100%;

--- a/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
+++ b/src/lib/Room/RoomMessage/MessageFiles/MessageFile/MessageFile.vue
@@ -24,19 +24,13 @@
           <slot :name="name" v-bind="data" />
         </template>
       </loader>
-      <div
-        class="vac-message-image"
-        :class="{
-          'vac-blur-loading':
-            isImageLoading && message.senderId === currentUserId
-        }"
-        :style="{
-          'background-image': `url('${
-            isImageLoading ? file.preview || file.url : file.url
-          }')`,
-          'max-height': `${imageResponsive.maxHeight}px`
-        }"
-      >
+      <div>
+        <img 
+          class="vac-message-image"
+          :class="{ 'vac-blur-loading': isImageLoading && message.senderId === currentUserId }"
+          :src="isImageLoading ? file.preview || file.url : file.url"
+          :style="{ 'max-height': `${imageResponsive.maxHeight}px` }"
+        />
         <transition name="vac-fade-image">
           <div
             v-if="!messageSelectionEnabled && imageHover && !isImageLoading"

--- a/src/lib/Room/RoomMessage/MessageReply/MessageReply.scss
+++ b/src/lib/Room/RoomMessage/MessageReply/MessageReply.scss
@@ -25,6 +25,7 @@
     width: 70px;
 
     .vac-message-image-reply {
+      object-fit: cover;
       height: 70px;
       width: 70px;
       margin: 4px auto 3px;

--- a/src/lib/Room/RoomMessage/MessageReply/MessageReply.vue
+++ b/src/lib/Room/RoomMessage/MessageReply/MessageReply.vue
@@ -5,12 +5,7 @@
     </div>
 
     <div v-if="isImage" class="vac-image-reply-container">
-      <div
-        class="vac-message-image vac-message-image-reply"
-        :style="{
-          'background-image': `url('${firstFile.url}')`
-        }"
-      />
+      <img class="vac-message-image vac-message-image-reply" :src="firstFile.url" />
     </div>
 
     <div v-else-if="isVideo" class="vac-video-reply-container">

--- a/src/lib/Room/RoomMessage/RoomMessage.scss
+++ b/src/lib/Room/RoomMessage/RoomMessage.scss
@@ -166,6 +166,7 @@
   }
 
   .vac-message-image {
+    object-fit: cover;
     position: relative;
     background-color: var(--chat-message-bg-color-image) !important;
     background-size: cover !important;


### PR DESCRIPTION
Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/1174

## Descrição
- Esse PR substitui os `background-image` usados nos anexos/medias pela tag `<img />`, minha hipotese é que por estar como `background-image` o DOM atualizava ao receber uma nova mensagem e o background-image era reaplicado, refazendo a consulta, assim com a tag img o browser deve fazer a cache devidamente e o vue deve se entender ao atualizar.

## Como testar
- Verificar todas as ocorrências de anexos/preview de imagens, nenhuma deve estar distorcida, fora isso tudo deve permanecer igual.
- Exeplos de teste:
  - enviar uma imagem no chat
  - fazer reply nessa imagem
  - ver ela na listagem da sidebar em `mídias, áudios e documentos` 

Fix: https://github.com/optidatacloud/optiwork-chat/issues/1174