### PR TITLE
fix: trigger file drop overlay only for files (issue #990)

### DIFF
--- a/src/utils/uploader-overlay/index.js
+++ b/src/utils/uploader-overlay/index.js
@@ -23,16 +23,22 @@ export default class FileUploaderOverlay {
     this.onDrag = event => {
       event.preventDefault()
 
-      switch (event.type) {
-      case 'dragenter':
-        this.addDragOverlay()
-        break
-      case 'dragleave':
-        this.removeDragOverlay()
-        break
+      const draggedItems = event.dataTransfer.items;
+      const hasFiles = Array.from(draggedItems).some(item => item.kind === 'file');
+      if (!hasFiles) {
+        return;
+      }
 
-      default:
-        break
+      switch (event.type) {
+        case 'dragenter':
+          this.addDragOverlay()
+          break
+        case 'dragleave':
+          this.removeDragOverlay()
+          break
+
+        default:
+          break
       }
     }
 


### PR DESCRIPTION
Resolve:
> - https://github.com/optidatacloud/optiwork-chat/issues/990

## Descrição
- Esse PR ajusta para que o overlay de "soltar arquivos" seja ativado apenas quando realmente tem arquivos sendo arrastados, e não texto como antes acontecia.

## Como testar
- Selecionar um texto dentro da conversa e arrastar, o overlay não deve ser ativado


Fix: https://github.com/optidatacloud/optiwork-chat/issues/990